### PR TITLE
Use namespaced `Title` class

### DIFF
--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -7,6 +7,8 @@
  */
 
 // Global constants
+use MediaWiki\Title\Title;
+
 define('MEDIATYPE_BITMAP', 'BITMAP');
 define('NS_FILE', 6);
 
@@ -51,16 +53,6 @@ class File {
      * @return ThumbnailImage|MediaTransformError
      */
     public function transform($params, $flags = 0) {}
-}
-
-class Title {
-    public static function newFromText(string $text, int $defaultNamespace = 0): ?Title {}
-    public static function makeTitleSafe(int $ns, string $title, string $fragment = '', string $interwiki = ''): ?Title {}
-    public function getDBkey(): string {}
-    public function getText(): string {}
-    public function getNamespace(): int {}
-    public function getNsText(): string {}
-    public function getPrefixedText(): string {}
 }
 
 class ThumbnailImage {

--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -3,6 +3,18 @@
  * PHPStan stubs for MediaWiki namespaced classes.
  */
 
+namespace MediaWiki\Title;
+
+class Title {
+    public static function newFromText(string $text, int $defaultNamespace = 0): ?Title {}
+    public static function makeTitleSafe(int $ns, string $title, string $fragment = '', string $interwiki = ''): ?Title {}
+    public function getDBkey(): string {}
+    public function getText(): string {}
+    public function getNamespace(): int {}
+    public function getNsText(): string {}
+    public function getPrefixedText(): string {}
+}
+
 namespace MediaWiki;
 
 class MediaWikiServices {

--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,7 @@
   "license-name": "MIT",
   "type": "other",
   "requires": {
-    "MediaWiki": ">= 1.39"
+    "MediaWiki": ">= 1.44"
   },
   "load_composer_autoloader": true,
   "AutoloadNamespaces": {

--- a/src/IIIFFile.php
+++ b/src/IIIFFile.php
@@ -7,8 +7,8 @@ namespace MediaWiki\Extension\InstantIIIF;
 use File;
 use MediaTransformError;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use ThumbnailImage;
-use Title;
 use Ubl\Iiif\Tools\IiifHelper;
 
 /**

--- a/src/Repo.php
+++ b/src/Repo.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MediaWiki\Extension\InstantIIIF;
 
 use FileRepo;
-use Title;
+use MediaWiki\Title\Title;
 
 class Repo extends FileRepo
 {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
`Error: Class "Title" not found`


**What is the new behavior (if this is a feature change)?**
Changed to namespaced `MediaWiki\Title\Title`


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, minimum required MediaWiki version changes from 1.39 to 1.44.


**Other information**:
No one uses this extension but me, so everything is fine.