### PR TITLE
Skip non-existing IIIF images

### DIFF
--- a/src/IIIFFile.php
+++ b/src/IIIFFile.php
@@ -388,6 +388,7 @@ class IIIFFile extends File
      *     manifestObj: object
      * }|null
      */
+    // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh -- Pending full refactor
     protected function ensureResolved(): ?array
     {
         if ($this->resolved !== null) {

--- a/src/IIIFFile.php
+++ b/src/IIIFFile.php
@@ -430,6 +430,10 @@ class IIIFFile extends File
             }
             $manifestRaw = json_decode($json, true) ?: [];
 
+            if ($this->isErrorManifest($manifestRaw)) {
+                continue;
+            }
+
             $this->resolved = [
                 'provider' => (string) ($src['id'] ?? 'default'),
                 'objectId' => $objId,
@@ -442,6 +446,22 @@ class IIIFFile extends File
 
         $this->resolved = null;
         return null;
+    }
+
+    /** @param array<string, mixed> $manifest */
+    private function isErrorManifest(array $manifest): bool
+    {
+        $label = $manifest['label'] ?? '';
+        if (is_string($label) && str_starts_with($label, 'error:')) {
+            return true;
+        }
+
+        $canvasId = $manifest['sequences'][0]['canvases'][0]['@id'] ?? '';
+        if (is_string($canvasId) && str_starts_with($canvasId, 'error/')) {
+            return true;
+        }
+
+        return false;
     }
 
     protected function removeImageExtension(string $filename): string


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Fixes #3


**What is the new behavior (if this is a feature change)?**
Check whether the returned manifest label starts with `error` and, if so, skip it.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
This issue may be specific to the IIIF provider ‘Deutsche Fotothek’, as the bislag extension has not been tested with other providers. Consequently, the fix is also specific to Deutsche Fotothek.