### PR TITLE
Fix "undefined array key `directory`" error

### DIFF
--- a/src/Repo.php
+++ b/src/Repo.php
@@ -17,6 +17,11 @@ class Repo extends FileRepo
      */
     public function __construct(array $info)
     {
+        // FileBackendGroup requires 'directory' for auto-backend creation;
+        // IIIF has no local storage, so we default to the upload dir.
+        if (!isset($info['directory'])) {
+            $info['directory'] = $GLOBALS['wgUploadDirectory'] ?? '';
+        }
         parent::__construct($info);
         $this->iiifSources = $info['iiifSources'] ?? [];
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Embedding an IIIF image causes
```
PHP Warning: Undefined array key "directory" in /path/to/mediawiki/includes/filebackend/FileBackendGroup.php on line 133
```


**What is the new behavior (if this is a feature change)?**
`directory` key is set to a sane default when not set in extension config (`LocalSettings.php`).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
