### PR TITLE
Hide meaningless metadata on single IIIF images

### DIFF
--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -76,6 +76,7 @@ class MediaTransformError {
 class OutputPage {
     /** @param string|string[] $modules */
     public function addModules($modules): void {}
+    public function addInlineStyle(string $style): void {}
 }
 
 class Skin {

--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -17,15 +17,22 @@ class Title {
 
 namespace MediaWiki;
 
+use GlobalVarConfig;
+use MediaWiki\Http\HttpRequestFactory;
+use RepoGroup;
+use WANObjectCache;
+
 class MediaWikiServices {
     public static function getInstance(): self {}
-    public function getMainConfig(): \GlobalVarConfig {}
-    public function getMainWANObjectCache(): \WANObjectCache {}
-    public function getHttpRequestFactory(): \MediaWiki\Http\HttpRequestFactory {}
-    public function getRepoGroup(): \RepoGroup {}
+    public function getMainConfig(): GlobalVarConfig {}
+    public function getMainWANObjectCache(): WANObjectCache {}
+    public function getHttpRequestFactory(): HttpRequestFactory {}
+    public function getRepoGroup(): RepoGroup {}
 }
 
 namespace MediaWiki\Http;
+
+use MWHttpRequest;
 
 class HttpRequestFactory {
     /**
@@ -33,7 +40,20 @@ class HttpRequestFactory {
      * @param array<string, mixed> $options
      * @param string|null $caller
      */
-    public function create(string $url, array $options = [], ?string $caller = null): \MWHttpRequest {}
+    public function create(string $url, array $options = [], ?string $caller = null): MWHttpRequest {}
+}
+
+namespace MediaWiki\Page;
+
+use File;
+use OutputPage;
+
+class ImageHistoryList {
+    public function getOutput(): OutputPage {}
+}
+
+class ImagePage {
+    public function getDisplayedFile(): File {}
 }
 
 namespace Wikimedia\ParamValidator;

--- a/extension.json
+++ b/extension.json
@@ -52,6 +52,12 @@
     ],
     "ThumbnailBeforeProduceHTML": [
       "MediaWiki\\Extension\\InstantIIIF\\Hooks::onThumbnailBeforeProduceHTML"
+    ],
+    "ImagePageFileHistoryLine": [
+      "MediaWiki\\Extension\\InstantIIIF\\Hooks::onImagePageFileHistoryLine"
+    ],
+    "ImagePageShowTOC": [
+      "MediaWiki\\Extension\\InstantIIIF\\Hooks::onImagePageShowTOC"
     ]
   }
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace MediaWiki\Extension\InstantIIIF;
 
+use File;
+use MediaWiki\Page\ImageHistoryList;
+use MediaWiki\Page\ImagePage;
 use MWNamespace;
 use OutputPage;
 use Skin;
@@ -58,5 +61,58 @@ class Hooks
             $imgAttrs['data-file-height'] = $thumb->getHeight();
         }
         return true;
+    }
+
+    /**
+     * Hide the file history section for IIIF files — version history is meaningless
+     * for hotlinked remote resources, and the single auto-generated row shows
+     * misleading data (no user, today's date).
+     *
+     * Suppressing the row alone still leaves the section heading rendered by
+     * ImageHistoryPseudoPager::getBody(), so we also inject CSS to hide it.
+     *
+     * Also hide the file info below the image; it shows 0 bytes file size.
+     *
+     * @param ImageHistoryList $imageHistoryList
+     * @param File $file
+     * @param string &$line
+     * @param string|null &$css
+     * @return bool
+     */
+    public static function onImagePageFileHistoryLine(
+        ImageHistoryList $imageHistoryList,
+        File $file,
+        string &$line,
+        ?string &$css
+    ): bool {
+
+        if (!$file instanceof IIIFFile) {
+            return true;
+        }
+
+        $imageHistoryList->getOutput()->addInlineStyle(
+            'h2#filehistory, #mw-imagepage-section-filehistory { display: none; }' .
+            ' span.fileInfo { display: none; }'
+        );
+        $line = '';
+        return false;
+    }
+
+    /**
+     * Remove the "File history" entry from the file page TOC for IIIF files.
+     *
+     * @param ImagePage $page
+     * @param string[] &$toc
+     */
+    public static function onImagePageShowTOC(ImagePage $page, array &$toc): void
+    {
+        if (!$page->getDisplayedFile() instanceof IIIFFile) {
+            return;
+        }
+
+        $toc = array_values(array_filter(
+            $toc,
+            static fn (string $item) => !str_contains($item, '#filehistory')
+        ));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Fixes #9


**What is the new behavior (if this is a feature change)?**
On single IIIF images,
* hide image file information that include wrong "0 bytes"
* hide "File history" section that includes wrong/meaningless information like today's upload date


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Wrong upload date on MultimediaViewer overlay will be fixed in a follow-up PR.