### PR TITLE
Remove wrong upload date on MMV

### DIFF
--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -43,6 +43,11 @@ class HttpRequestFactory {
     public function create(string $url, array $options = [], ?string $caller = null): MWHttpRequest {}
 }
 
+namespace MediaWiki\Context;
+
+interface IContextSource {
+}
+
 namespace MediaWiki\Page;
 
 use File;

--- a/extension.json
+++ b/extension.json
@@ -58,6 +58,9 @@
     ],
     "ImagePageShowTOC": [
       "MediaWiki\\Extension\\InstantIIIF\\Hooks::onImagePageShowTOC"
+    ],
+    "GetExtendedMetadata": [
+      "MediaWiki\\Extension\\InstantIIIF\\Hooks::onGetExtendedMetadata"
     ]
   }
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MediaWiki\Extension\InstantIIIF;
 
 use File;
+use MediaWiki\Context\IContextSource;
 use MediaWiki\Page\ImageHistoryList;
 use MediaWiki\Page\ImagePage;
 use MWNamespace;
@@ -36,7 +37,7 @@ class Hooks
     ): bool {
 
         $file = $thumb->getFile();
-        if ($file instanceof \MediaWiki\Extension\InstantIIIF\IIIFFile) {
+        if ($file instanceof IIIFFile) {
             $title = $file->getTitle();
             if ($title === null) {
                 return true;
@@ -114,5 +115,37 @@ class Hooks
             $toc,
             static fn (string $item) => !str_contains($item, '#filehistory')
         ));
+    }
+
+    /**
+     * Remove the wrong upload date from extmetadata for IIIF files.
+     *
+     * FormatMetadata generates a DateTime fallback via
+     * wfTimestamp(TS_ISO_8601, $file->getTimestamp()).
+     * Since IIIFFile::getTimestamp() returns false (no local storage), wfTimestamp interprets
+     * false as "now" and produces today's date. MMV then displays it as "Uploaded: <today>".
+     *
+     * @param array<string, mixed> &$combinedMeta
+     * @param File $file
+     * @param IContextSource $context
+     * @param bool $single
+     * @param int|null &$maxCacheTime
+     */
+    public static function onGetExtendedMetadata(
+        array &$combinedMeta,
+        File $file,
+        IContextSource $context,
+        bool $single,
+        ?int &$maxCacheTime
+    ): void {
+
+        if (!$file instanceof IIIFFile) {
+            return;
+        }
+        // Value must survive CommonsMetadata's normalizeMetadataTimestamps (which converts
+        // empty strings to "now" via wfTimestamp) and MMV's parseExtmeta which strips HTML
+        // tags and skips display when the result is falsy.
+        $combinedMeta['DateTime'] = ['value' => '<>', 'source' => 'mediawiki-metadata'];
+        $maxCacheTime = 0;
     }
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -118,12 +118,15 @@ class Hooks
     }
 
     /**
-     * Remove the wrong upload date from extmetadata for IIIF files.
+     * Suppress the spurious upload date from extmetadata for IIIF files.
      *
-     * FormatMetadata generates a DateTime fallback via
-     * wfTimestamp(TS_ISO_8601, $file->getTimestamp()).
-     * Since IIIFFile::getTimestamp() returns false (no local storage), wfTimestamp interprets
-     * false as "now" and produces today's date. MMV then displays it as "Uploaded: <today>".
+     * FormatMetadata falls back to wfTimestamp($file->getTimestamp()), which
+     * returns "now" for IIIF files (no local storage → getTimestamp() is false).
+     * The value cannot simply be set to '' because CommonsMetadata's
+     * normalizeMetadataTimestamps() would re-parse the empty string back into
+     * "now" via wfTimestamp. The '<>' sentinel survives that step (wfTimestamp
+     * returns false for non-date strings) and is stripped to '' by MMV's
+     * parseExtmeta, which then skips the "Uploaded" label for falsy values.
      *
      * @param array<string, mixed> &$combinedMeta
      * @param File $file
@@ -142,10 +145,6 @@ class Hooks
         if (!$file instanceof IIIFFile) {
             return;
         }
-        // Value must survive CommonsMetadata's normalizeMetadataTimestamps (which converts
-        // empty strings to "now" via wfTimestamp) and MMV's parseExtmeta which strips HTML
-        // tags and skips display when the result is falsy.
         $combinedMeta['DateTime'] = ['value' => '<>', 'source' => 'mediawiki-metadata'];
-        $maxCacheTime = 0;
     }
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -145,6 +145,6 @@ class Hooks
         if (!$file instanceof IIIFFile) {
             return;
         }
-        $combinedMeta['DateTime'] = ['value' => '<>', 'source' => 'mediawiki-metadata'];
+        $combinedMeta['DateTime'] = ['value' => '<>', 'source' => 'extension'];
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
The MultimediaViewer overlay shows "Uploaded: <today's date>" for IIIF files. 


**What is the new behavior (if this is a feature change)?**
The "Uploaded" date is suppressed for IIIF files.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
`FormatMetadata` falls back to `wfTimestamp($file->getTimestamp())`, which returns "now" for IIIF files (no local storage → `getTimestamp()` is `false`). The value cannot simply be set to `''` because `CommonsMetadata`'s `normalizeMetadataTimestamps()` would re-parse the empty string back into "now" via `wfTimestamp`. The `'<>'` sentinel survives that step (`wfTimestamp` returns `false` for non-date strings) and is stripped to `''` by MMV's `parseExtmeta`, which then skips the "Uploaded" label for falsy values.