### PR TITLE
Remove `ubl/php-iiif-prezi-reader` library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=8.4",
-    "ubl/php-iiif-prezi-reader": "^0.3.0"
+    "ext-mbstring": "*"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,104 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8411af2883dc909d150ddbe899a4cfc",
-    "packages": [
-        {
-            "name": "flow/jsonpath",
-            "version": "0.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FlowCommunications/JSONPath.git",
-                "reference": "b9738858c75d008c1211612b973e9510f8b7f8ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FlowCommunications/JSONPath/zipball/b9738858c75d008c1211612b973e9510f8b7f8ea",
-                "reference": "b9738858c75d008c1211612b973e9510f8b7f8ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "peekmo/jsonpath": "dev-master",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Flow\\JSONPath": "src/",
-                    "Flow\\JSONPath\\Test": "tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Stephen Frank",
-                    "email": "stephen@flowsa.com"
-                }
-            ],
-            "description": "JSONPath implementation for parsing, searching and flattening arrays",
-            "support": {
-                "issues": "https://github.com/FlowCommunications/JSONPath/issues",
-                "source": "https://github.com/FlowCommunications/JSONPath/tree/0.5.0"
-            },
-            "abandoned": "softcreatr/jsonpath",
-            "time": "2019-07-15T17:23:22+00:00"
-        },
-        {
-            "name": "ubl/php-iiif-prezi-reader",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ubleipzig/php-iiif-prezi-reader.git",
-                "reference": "401d246af3fc2857d1a925339fea256ac32824f6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ubleipzig/php-iiif-prezi-reader/zipball/401d246af3fc2857d1a925339fea256ac32824f6",
-                "reference": "401d246af3fc2857d1a925339fea256ac32824f6",
-                "shasum": ""
-            },
-            "require": {
-                "flow/jsonpath": ">=0.4.0",
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ubl\\Iiif\\": "src/Iiif/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Lutz Helm",
-                    "email": "helm@ub.uni-leipzig.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Read IIIF Presentation API resources into PHP objects that offer some convenient data extraction methods",
-            "keywords": [
-                "iiif",
-                "iiif-presentation"
-            ],
-            "support": {
-                "issues": "https://github.com/ubleipzig/php-iiif-prezi-reader/issues",
-                "source": "https://github.com/ubleipzig/php-iiif-prezi-reader/tree/0.3.0"
-            },
-            "time": "2019-09-13T13:54:17+00:00"
-        }
-    ],
+    "content-hash": "8abda445f737c2dad562b8b7ad5b7b2c",
+    "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
@@ -159,16 +63,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -251,7 +155,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -520,16 +424,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.1",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -561,9 +465,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2026-01-12T11:33:04+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -956,7 +860,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4"
+        "php": ">=8.4",
+        "ext-mbstring": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/src/IIIFFile.php
+++ b/src/IIIFFile.php
@@ -9,7 +9,6 @@ use MediaTransformError;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use ThumbnailImage;
-use Ubl\Iiif\Tools\IiifHelper;
 
 /**
  * Virtual File that hotlinks images from a remote IIIF Image Service using
@@ -22,8 +21,7 @@ class IIIFFile extends File
      *     provider: string,
      *     objectId: string,
      *     manifestUrl: string,
-     *     manifestRaw: array<string, mixed>,
-     *     manifestObj: object
+     *     manifestRaw: array<string, mixed>
      * }|null
      */
     protected ?array $resolved = null;
@@ -138,14 +136,14 @@ class IIIFFile extends File
             return '';
         }
 
-        $manifestObj = $resolved['manifestObj'];
+        $manifest = $resolved['manifestRaw'];
 
-        $homepageUrl = $this->extractHomepageFromManifest($manifestObj);
+        $homepageUrl = $this->extractHomepageUrl($manifest);
         if ($homepageUrl !== null) {
             return $homepageUrl;
         }
 
-        $relatedUrl = $this->extractRelatedFromManifest($manifestObj);
+        $relatedUrl = $this->extractRelatedUrl($manifest);
         if ($relatedUrl !== null) {
             return $relatedUrl;
         }
@@ -171,61 +169,62 @@ class IIIFFile extends File
         return $this->getDescriptionUrl();
     }
 
+    /* -------------------- Description URL extraction -------------------- */
+
     /**
-     * Extract homepage URL from a manifest object (v3 style).
+     * Extract homepage URL from manifest (v3: `homepage` field).
+     *
+     * @param array<string, mixed> $manifest
      */
-    private function extractHomepageFromManifest(object $manifestObj): ?string
+    private function extractHomepageUrl(array $manifest): ?string
     {
-        if (!method_exists($manifestObj, 'getHomepage')) {
+        $homepage = $manifest['homepage'] ?? null;
+        if ($homepage === null) {
             return null;
         }
 
-        try {
-            $homepage = $manifestObj->getHomepage();
-            return $this->extractIdFromResource($homepage);
-        } catch (\Throwable $exception) {
-            return null;
-        }
+        return $this->extractHttpUrl($homepage);
     }
 
     /**
-     * Extract related URL from a manifest object (v2 style).
+     * Extract related URL from manifest (v2: `related` field).
+     *
+     * @param array<string, mixed> $manifest
      */
-    private function extractRelatedFromManifest(object $manifestObj): ?string
+    private function extractRelatedUrl(array $manifest): ?string
     {
-        if (!method_exists($manifestObj, 'getRelated')) {
+        $related = $manifest['related'] ?? null;
+        if ($related === null) {
             return null;
         }
 
-        try {
-            $related = $manifestObj->getRelated();
-            if (is_string($related) && preg_match('~^https?://~', $related)) {
-                return $related;
-            }
-            return $this->extractIdFromResource($related);
-        } catch (\Throwable $exception) {
-            return null;
-        }
+        return $this->extractHttpUrl($related);
     }
 
     /**
-     * Extract ID from a resource object or array.
+     * Extract an HTTP(S) URL from a value that may be a string, an object
+     * with `@id`/`id`, or an array of such objects.
      */
-    private function extractIdFromResource(mixed $resource): ?string
+    private function extractHttpUrl(mixed $value): ?string
     {
-        if (is_object($resource) && method_exists($resource, 'getId')) {
-            $resourceId = $resource->getId();
-            if (is_string($resourceId) && preg_match('~^https?://~', $resourceId)) {
-                return $resourceId;
-            }
+        // Plain URL string.
+        if (is_string($value) && preg_match('~^https?://~', $value)) {
+            return $value;
         }
 
-        if (is_array($resource) && isset($resource[0])) {
-            $first = $resource[0];
-            if (is_object($first) && method_exists($first, 'getId')) {
-                $resourceId = $first->getId();
-                if (is_string($resourceId) && preg_match('~^https?://~', $resourceId)) {
-                    return $resourceId;
+        // Single object with @id or id.
+        if (is_array($value)) {
+            $id = $value['@id'] ?? $value['id'] ?? null;
+            if (is_string($id) && preg_match('~^https?://~', $id)) {
+                return $id;
+            }
+
+            // Array of objects — use the first one.
+            $first = $value[0] ?? null;
+            if (is_array($first)) {
+                $id = $first['@id'] ?? $first['id'] ?? null;
+                if (is_string($id) && preg_match('~^https?://~', $id)) {
+                    return $id;
                 }
             }
         }
@@ -400,16 +399,6 @@ class IIIFFile extends File
         return $pageNum >= 1 ? $pageNum : 1;
     }
 
-    /**
-     * @return array{
-     *     provider: string,
-     *     objectId: string,
-     *     manifestUrl: string,
-     *     manifestRaw: array<string, mixed>,
-     *     manifestObj: object
-     * }|null
-     */
-
     /** @return array<string, mixed>|null */
     // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- MediaWiki File override
     public function getResolvedManifest(): ?array
@@ -422,8 +411,7 @@ class IIIFFile extends File
      *     provider: string,
      *     objectId: string,
      *     manifestUrl: string,
-     *     manifestRaw: array<string, mixed>,
-     *     manifestObj: object
+     *     manifestRaw: array<string, mixed>
      * }|null
      */
     // phpcs:ignore SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh -- Pending full refactor
@@ -462,11 +450,6 @@ class IIIFFile extends File
                 continue;
             }
 
-            // Reader is mandatory; parse once.
-            $manifestObj = IiifHelper::loadIiifResource($json);
-            if ($manifestObj === null) {
-                continue;
-            }
             $manifestRaw = json_decode($json, true) ?: [];
 
             if ($this->isErrorManifest($manifestRaw)) {
@@ -478,7 +461,6 @@ class IIIFFile extends File
                 'objectId' => $objId,
                 'manifestUrl' => $manifestUrl,
                 'manifestRaw' => $manifestRaw,
-                'manifestObj' => $manifestObj,
             ];
             return $this->resolved;
         }
@@ -532,7 +514,7 @@ class IIIFFile extends File
         if (!$resolved) {
             return null;
         }
-        return $this->extractServiceFromReader($resolved['manifestObj'], $page);
+        return $this->extractServiceId($resolved['manifestRaw'], $page);
     }
 
     /**
@@ -545,7 +527,7 @@ class IIIFFile extends File
         if (!$resolved) {
             return [0, 0];
         }
-        return $this->extractCanvasDimsFromReader($resolved['manifestObj'], $page);
+        return $this->extractCanvasDimensions($resolved['manifestRaw'], $page);
     }
 
     /**
@@ -585,7 +567,7 @@ class IIIFFile extends File
     }
 
     /**
-     * Passt angefragte w/h an die vom Dienst unterstützten Limits an.
+     * Clamp requested w/h to the limits supported by the image service.
      *
      * @return array{0: int, 1: int}
      */
@@ -762,101 +744,94 @@ class IIIFFile extends File
         return $arr;
     }
 
-    /* -------------------- Reader-based extraction -------------------- */
+    /* -------------------- Raw JSON manifest extraction -------------------- */
 
-    private function extractServiceFromReader(object $manifestObj, int $page): ?string
+    /**
+     * Get the list of canvases from the manifest.
+     * v2: sequences[0].canvases, v3: items.
+     *
+     * @param array<string, mixed> $manifest
+     * @return array<int, array<string, mixed>>
+     */
+    private function getCanvases(array $manifest): array
     {
-        $idx = max(0, $page - 1);
-        $canvases = $this->getCanvasesFromManifest($manifestObj);
+        // v3
+        if (isset($manifest['items']) && is_array($manifest['items'])) {
+            return $manifest['items'];
+        }
 
-        if (!$canvases || !isset($canvases[$idx])) {
+        // v2
+        $canvases = $manifest['sequences'][0]['canvases'] ?? null;
+        if (is_array($canvases)) {
+            return $canvases;
+        }
+
+        return [];
+    }
+
+    /**
+     * Extract the IIIF Image API service @id for a given page.
+     *
+     * @param array<string, mixed> $manifest
+     */
+    private function extractServiceId(array $manifest, int $page): ?string
+    {
+        $canvases = $this->getCanvases($manifest);
+        $idx = max(0, $page - 1);
+        if (!isset($canvases[$idx]) || !is_array($canvases[$idx])) {
             return null;
         }
         $canvas = $canvases[$idx];
 
-        // Try v3 path first.
+        // v3: items[0].items[0].body.service[0].@id (or .id)
         $serviceId = $this->extractServiceFromV3Canvas($canvas);
         if ($serviceId !== null) {
             return $serviceId;
         }
 
-        // Fall back to v2 path.
+        // v2: images[0].resource.service.@id
         return $this->extractServiceFromV2Canvas($canvas);
     }
 
     /**
-     * @return array<mixed>|null
+     * v3 canvas: items (AnnotationPage) → items (Annotation) → body → service.
+     *
+     * @param array<string, mixed> $canvas
      */
-    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- internal accessor
-    private function getCanvasesFromManifest(object $manifestObj): ?array
+    private function extractServiceFromV3Canvas(array $canvas): ?string
     {
-        $canvases = method_exists($manifestObj, 'getItems')
-            ? $manifestObj->getItems()
-            : null;
-
-        if (!$canvases && method_exists($manifestObj, 'getSequences')) {
-            $seq = $manifestObj->getSequences()[0] ?? null;
-            $canvases = $seq ? $seq->getCanvases() : null;
+        $body = $canvas['items'][0]['items'][0]['body'] ?? null;
+        if (!is_array($body)) {
+            return null;
         }
 
-        return $canvases;
+        $service = $body['service'] ?? null;
+        return $this->extractServiceIdFromField($service);
     }
 
-    private function extractServiceFromV3Canvas(object $canvas): ?string
+    /**
+     * v2 canvas: images[0].resource.service.
+     *
+     * @param array<string, mixed> $canvas
+     */
+    private function extractServiceFromV2Canvas(array $canvas): ?string
     {
-        $items = method_exists($canvas, 'getItems') ? $canvas->getItems() : null;
-        if (!$items) {
+        $resource = $canvas['images'][0]['resource'] ?? null;
+        if (!is_array($resource)) {
             return null;
         }
 
-        $annopage = $items[0] ?? null;
-        if (!is_object($annopage)) {
-            return null;
-        }
-        $annos = method_exists($annopage, 'getItems') ? $annopage->getItems() : null;
-        $anno = $annos[0] ?? null;
-        if (!is_object($anno)) {
-            return null;
-        }
-        $body = method_exists($anno, 'getBody') ? $anno->getBody() : null;
-
-        if (is_object($body) && method_exists($body, 'getService')) {
-            $svc = $body->getService();
-            if (is_object($svc) && method_exists($svc, 'getId')) {
-                return rtrim($svc->getId(), '/');
-            }
+        $service = $resource['service'] ?? null;
+        $id = $this->extractServiceIdFromField($service);
+        if ($id !== null) {
+            return $id;
         }
 
-        return null;
-    }
-
-    private function extractServiceFromV2Canvas(object $canvas): ?string
-    {
-        if (!method_exists($canvas, 'getImages')) {
-            return null;
-        }
-
-        $img = $canvas->getImages()[0] ?? null;
-        if (!is_object($img) || !method_exists($img, 'getResource')) {
-            return null;
-        }
-
-        $res = $img->getResource();
-        if (!is_object($res)) {
-            return null;
-        }
-
-        if (method_exists($res, 'getService')) {
-            $svc = $res->getService();
-            if (is_object($svc) && method_exists($svc, 'getId')) {
-                return rtrim($svc->getId(), '/');
-            }
-        }
-
-        if (method_exists($res, 'getId')) {
-            $resourceId = $res->getId();
+        // Fallback: try to derive service base from the resource @id URL.
+        $resourceId = $resource['@id'] ?? null;
+        if (is_string($resourceId)) {
             $pattern = '#^(.*?/iiif/2/[^/]+)#';
-            if (is_string($resourceId) && preg_match($pattern, $resourceId, $match)) {
+            if (preg_match($pattern, $resourceId, $match)) {
                 return $match[1];
             }
         }
@@ -865,26 +840,58 @@ class IIIFFile extends File
     }
 
     /**
+     * Extract the service base URL from a `service` field.
+     * Handles both a single service object and an array of services.
+     */
+    private function extractServiceIdFromField(mixed $service): ?string
+    {
+        if (!is_array($service)) {
+            return null;
+        }
+
+        // Single service object with @id or id key.
+        $id = $service['@id'] ?? $service['id'] ?? null;
+        if (is_string($id)) {
+            return rtrim($id, '/');
+        }
+
+        // Array of service objects — use the first entry.
+        $first = $service[0] ?? null;
+        if (is_array($first)) {
+            $id = $first['@id'] ?? $first['id'] ?? null;
+            if (is_string($id)) {
+                return rtrim($id, '/');
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract canvas dimensions for a given page.
+     *
+     * @param array<string, mixed> $manifest
      * @return array{0: int, 1: int}
      */
-    private function extractCanvasDimsFromReader(object $manifestObj, int $page): array
+    private function extractCanvasDimensions(array $manifest, int $page): array
     {
+        $canvases = $this->getCanvases($manifest);
         $idx = max(0, $page - 1);
-        $canvases = $this->getCanvasesFromManifest($manifestObj);
-
-        if (!$canvases || !isset($canvases[$idx])) {
+        if (!isset($canvases[$idx]) || !is_array($canvases[$idx])) {
             return [0, 0];
         }
         $canvas = $canvases[$idx];
-        if (!is_object($canvas)) {
-            return [0, 0];
-        }
 
-        $width = method_exists($canvas, 'getWidth') ? (int) $canvas->getWidth() : 0;
-        $height = method_exists($canvas, 'getHeight') ? (int) $canvas->getHeight() : 0;
+        $width = (int) ($canvas['width'] ?? 0);
+        $height = (int) ($canvas['height'] ?? 0);
         return [$width, $height];
     }
 
+    /**
+     * Resolve a IIIF value that may be a plain string, a v2 language object
+     * (`{ "@value": "...", "@language": "..." }`), a v3 language map
+     * (`{ "en": ["..."], "de": ["..."] }`), or an array of language objects.
+     */
     private function stringFromMaybeLangMap(mixed $value): string
     {
         if (is_string($value)) {
@@ -895,13 +902,21 @@ class IIIFFile extends File
             return '';
         }
 
+        // v2 single language object.
         if (isset($value['@value']) && is_string($value['@value'])) {
             return $value['@value'];
         }
 
-        foreach ($value as $langVals) {
-            if (is_array($langVals) && isset($langVals[0]) && is_string($langVals[0])) {
-                return $langVals[0];
+        // v2 array of language objects.
+        $first = $value[0] ?? null;
+        if (is_array($first) && isset($first['@value']) && is_string($first['@value'])) {
+            return $first['@value'];
+        }
+
+        // v3 language map — pick the first available translation.
+        foreach ($value as $langValues) {
+            if (is_array($langValues) && isset($langValues[0]) && is_string($langValues[0])) {
+                return $langValues[0];
             }
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Fixes #6


**What is the new behavior (if this is a feature change)?**
https://github.com/ubleipzig/php-iiif-prezi-reader library removed


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
`ubl/php-iiif-prezi-reader` is unmaintained (see https://github.com/ubleipzig/php-iiif-prezi-reader/issues/2) and potentially buggy (doesn't support language maps). Also, the extension only use a very small portion of the library features.