### PR TITLE
Add multi-page support

### DIFF
--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -28,7 +28,7 @@ class FileRepo {
 class MediaTransformOutput {
 }
 
-class MediaHandler {
+abstract class MediaHandler {
     /** @return array<string, string> */
     public function getParamMap(): array {}
     /** @param string $name @param mixed $value */

--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -25,9 +25,44 @@ class FileRepo {
     public function getName(): string {}
 }
 
+class MediaTransformOutput {
+}
+
+class MediaHandler {
+    /** @return array<string, string> */
+    public function getParamMap(): array {}
+    /** @param string $name @param mixed $value */
+    public function validateParam($name, $value): bool {}
+    /** @param array<string, mixed> $params @return string|false */
+    public function makeParamString($params) {}
+    /** @param string $str @return array<string, mixed>|false */
+    public function parseParamString($str) {}
+    /** @param mixed $state @param string $path @return array<string, mixed> */
+    public function getSizeAndMetadata($state, $path): array {}
+    /** @param File $file */
+    public function mustRender($file): bool {}
+    /** @param File $file */
+    public function isExpensiveToThumbnail($file): bool {}
+    /**
+     * @param File $image
+     * @param string $dstPath
+     * @param string $dstUrl
+     * @param array<string, mixed> $params
+     * @param int $flags
+     * @return MediaTransformOutput
+     */
+    abstract public function doTransform($image, $dstPath, $dstUrl, $params, $flags = 0);
+}
+
+abstract class ImageHandler extends MediaHandler {
+}
+
 class File {
     /** @var FileRepo */
     public $repo;
+
+    /** @var MediaHandler|false */
+    protected $handler;
 
     /**
      * @param Title $title
@@ -39,6 +74,10 @@ class File {
     public function getSize(): int {}
     public function getMimeType(): string {}
     public function getMediaType(): string {}
+    public function isMultipage(): bool {}
+    public function pageCount(): int {}
+    /** @return MediaHandler|false */
+    public function getHandler() {}
     /** @param int $page */
     public function getWidth($page = 1): int {}
     /** @param int $page */
@@ -55,7 +94,7 @@ class File {
     public function transform($params, $flags = 0) {}
 }
 
-class ThumbnailImage {
+class ThumbnailImage extends MediaTransformOutput {
     /**
      * @param File $file
      * @param string $url
@@ -66,7 +105,6 @@ class ThumbnailImage {
     public function getFile(): File {}
     public function getWidth(): int {}
     public function getHeight(): int {}
-    public function getUrl(): string {}
 }
 
 class MediaTransformError {
@@ -92,29 +130,9 @@ class ApiQueryBase {
 
     public function __construct(ApiQuery $query, string $moduleName) {}
     public function execute(): void {}
-
-    /** @return array<string, mixed> */
-    public function extractRequestParams(): array {}
-    public function getModuleName(): string {}
-    public function getResult(): ApiResult {}
-
-    /** @return array<string, array<string, mixed>> */
-    public function getAllowedParams(): array {}
-
-    /** @return array<string, string> */
-    protected function getExamplesMessages(): array {}
 }
 
 class ApiQuery {
-}
-
-class ApiResult {
-    /**
-     * @param array<string|int>|null $path
-     * @param string|int $name
-     * @param mixed $value
-     */
-    public function addValue($path, $name, $value): bool {}
 }
 
 class GlobalVarConfig {
@@ -141,7 +159,6 @@ class MWHttpRequest {
 
 class StatusValue {
     public function isOK(): bool {}
-    public function isGood(): bool {}
 }
 
 /**
@@ -156,12 +173,4 @@ class Message {
     public function plain(): string {}
     public function parse(): string {}
     public function inContentLanguage(): self {}
-}
-
-class RepoGroup {
-    /** @return array<string, array<string, mixed>> */
-    public function getLocalInfo(): array {}
-    /** @return array<int, array<string, mixed>> */
-    public function getForeignInfo(): array {}
-    public function getRepo(string $name): ?FileRepo {}
 }

--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -8,8 +8,6 @@ namespace MediaWiki\Title;
 class Title {
     public static function newFromText(string $text, int $defaultNamespace = 0): ?Title {}
     public function getDBkey(): string {}
-    public function getText(): string {}
-    public function getNamespace(): int {}
     public function getNsText(): string {}
 }
 

--- a/resources/mmv-patch.js
+++ b/resources/mmv-patch.js
@@ -9,11 +9,49 @@ mw.loader.using( 'mediawiki.Title' ).then( function () {
         return orig( img );
     };
 
-    // --- Share-URL fix for IIIF files ---
-    // MMV appends #/media/File:… to the share URL via Config.getMediaHash().
-    // That fragment only makes sense on local wiki pages; on an external
-    // IIIF provider URL it is meaningless.
+    // --- IIIF-specific MMV patches ---
 
+    // Build a map of thumbnail src URL → IIIF page number from the DOM.
+    // This must happen before MMV opens so the patch can look up the page.
+    const iiifPageByUrl = new Map();
+    document.querySelectorAll( 'img[data-iiif-page]' ).forEach( function ( img ) {
+        const page = parseInt( img.getAttribute( 'data-iiif-page' ), 10 );
+        if ( page > 1 ) {
+            iiifPageByUrl.set( img.getAttribute( 'src' ), page );
+        }
+    } );
+
+    // Eagerly patch ThumbnailInfo so the fix is in place before MMV opens.
+    // MMV's ThumbnailInfo.get() extracts a page number from the sampleUrl
+    // via the regex /(lang|page)([\d\-a-z]+)-(\d+)px/. IIIF Image API URLs
+    // don't contain this pattern, so iiurlparam stays undefined and the
+    // API call returns page 1 regardless.
+    //
+    // Fix: when the sampleUrl maps to a known IIIF page > 1, append a
+    // fragment "#pageN-Wpx" that the regex picks up. ThumbnailInfo then
+    // sends iiurlparam=pageN-{width}px to the API, which
+    // IIIFHandler::parseParamString() parses into {page: N, width: W}.
+    // The "#" fragment is harmless — it never reaches the HTTP request.
+    let thumbnailInfoPatched = false;
+    if ( iiifPageByUrl.size > 0 ) {
+        mw.loader.using( 'mmv' ).then( function ( require ) {
+            const ThumbnailInfo = require( 'mmv' ).ThumbnailInfo;
+            const origGet = ThumbnailInfo.prototype.get;
+            ThumbnailInfo.prototype.get = function ( file, sampleUrl, width, height ) {
+                if ( sampleUrl ) {
+                    const page = iiifPageByUrl.get( sampleUrl );
+                    if ( page ) {
+                        const marker = 'page' + page + '-' + ( width || 300 ) + 'px';
+                        return origGet.call( this, file, sampleUrl + '#' + marker, width, height );
+                    }
+                }
+                return origGet.call( this, file, sampleUrl, width, height );
+            };
+            thumbnailInfoPatched = true;
+        } );
+    }
+
+    // --- Share-URL fix and state tracking via mmv-metadata ---
     let isCurrentImageIiif = false;
     let shareSetPatched = false;
 
@@ -23,28 +61,53 @@ mw.loader.using( 'mediawiki.Title' ).then( function () {
         isCurrentImageIiif = !!( image && image.thumbnail &&
             image.thumbnail.hasAttribute( 'data-iiif-title' ) );
 
-        if ( !isCurrentImageIiif || shareSetPatched ) {
+        if ( !isCurrentImageIiif ) {
             return;
         }
 
-        // mmv.ui.reuse is lazy-loaded but exports Share. Patch
-        // Share.prototype.set once to strip the hash for IIIF files.
-        // At this point mmv.bootstrap is already loaded (MMV is running),
-        // but mmv.ui.reuse may not be. mw.loader.using will load it on
-        // demand or return immediately if already loaded.
-        mw.loader.using( 'mmv.ui.reuse' ).then( function ( require ) {
-            const Share = require( 'mmv.ui.reuse' ).Share;
-            const origSet = Share.prototype.set;
-            Share.prototype.set = function ( image ) {
-                origSet.call( this, image );
-                if ( isCurrentImageIiif ) {
-                    const val = this.$pageInput.val();
-                    if ( val && val.includes( '#' ) ) {
-                        this.$pageInput.val( val.replace( /#.*$/, '' ) );
+        // Share-URL fix: MMV appends #/media/File:… via Config.getMediaHash().
+        // That fragment only makes sense on local wiki pages; on an external
+        // IIIF provider URL it is meaningless.
+        if ( !shareSetPatched ) {
+            mw.loader.using( 'mmv.ui.reuse' ).then( function ( require ) {
+                const Share = require( 'mmv.ui.reuse' ).Share;
+                const origSet = Share.prototype.set;
+                Share.prototype.set = function ( image ) {
+                    origSet.call( this, image );
+                    if ( isCurrentImageIiif ) {
+                        const val = this.$pageInput.val();
+                        if ( val && val.includes( '#' ) ) {
+                            this.$pageInput.val( val.replace( /#.*$/, '' ) );
+                        }
                     }
-                }
-            };
-            shareSetPatched = true;
-        } );
+                };
+                shareSetPatched = true;
+            } );
+        }
+
+        // Late ThumbnailInfo patch for pages loaded without multi-page images
+        // but where MMV navigates to one (e.g. via prev/next arrows).
+        if ( !thumbnailInfoPatched && image.thumbnail &&
+            image.thumbnail.hasAttribute( 'data-iiif-page' ) ) {
+            const page = parseInt( image.thumbnail.getAttribute( 'data-iiif-page' ), 10 );
+            if ( page > 1 && image.src ) {
+                iiifPageByUrl.set( image.src, page );
+            }
+            mw.loader.using( 'mmv' ).then( function ( require ) {
+                const ThumbnailInfo = require( 'mmv' ).ThumbnailInfo;
+                const origGet = ThumbnailInfo.prototype.get;
+                ThumbnailInfo.prototype.get = function ( file, sampleUrl, width, height ) {
+                    if ( sampleUrl ) {
+                        const pg = iiifPageByUrl.get( sampleUrl );
+                        if ( pg ) {
+                            const marker = 'page' + pg + '-' + ( width || 300 ) + 'px';
+                            return origGet.call( this, file, sampleUrl + '#' + marker, width, height );
+                        }
+                    }
+                    return origGet.call( this, file, sampleUrl, width, height );
+                };
+                thumbnailInfoPatched = true;
+            } );
+        }
     } );
 } );

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -60,6 +60,12 @@ class Hooks
             // Bonus: Include dimensions (helps MMV).
             $imgAttrs['data-file-width'] = $thumb->getWidth();
             $imgAttrs['data-file-height'] = $thumb->getHeight();
+
+            // For multi-page documents, include the page number so that
+            // the JS patch can forward it to MMV's ThumbnailInfo API call.
+            if ($file->isMultipage()) {
+                $imgAttrs['data-iiif-page'] = $file->lastTransformPage();
+            }
         }
         return true;
     }

--- a/src/IIIFFile.php
+++ b/src/IIIFFile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MediaWiki\Extension\InstantIIIF;
 
 use File;
+use MediaHandler;
 use MediaTransformError;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
@@ -29,7 +30,14 @@ class IIIFFile extends File
     /** @var array<string, array<string, mixed>> Cache for info.json per image service id */
     protected array $infoJsonMap = [];
 
+    /**
+     * Page number from the most recent transform() call.
+     * Read by Hooks::onThumbnailBeforeProduceHTML to set data-iiif-page.
+     */
+    protected int $lastTransformPage = 1;
+
     /** Provider-specific label mapping to find landing/homepage URL in `metadata` */
+    /** @var array<string, list<string>> */
     private const LANDING_META_KEYS = [
         'deutsche-fotothek' => ['Link zum Werk'],
     ];
@@ -71,6 +79,46 @@ class IIIFFile extends File
     }
 
     /**
+     * Return the custom IIIFHandler instead of JpegHandler.
+     *
+     * The base File class picks the handler via getMimeType() (image/jpeg
+     * → JpegHandler), which does not support the `page` parameter.
+     * Overriding here lets us use IIIFHandler with multi-page support.
+     *
+     * @return MediaHandler|false
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound, Syde.Functions.ReturnTypeDeclaration.NoReturnType -- MediaWiki File override
+    public function getHandler()
+    {
+        if (!$this->handler) {
+            $this->handler = new IIIFHandler();
+        }
+        return $this->handler;
+    }
+
+    /**
+     * A manifest with more than one canvas represents a multi-page document.
+     * This tells MediaWiki to pass the `page=` parameter through to
+     * getWidth(), getHeight(), and transform().
+     */
+    public function isMultipage(): bool
+    {
+        return $this->pageCount() > 1;
+    }
+
+    /**
+     * Number of pages (canvases) in the IIIF manifest.
+     */
+    public function pageCount(): int
+    {
+        $resolved = $this->ensureResolved();
+        if (!$resolved) {
+            return 0;
+        }
+        return count($this->getCanvases($resolved['manifestRaw']));
+    }
+
+    /**
      * @param int $page
      */
     // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound, Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki File override
@@ -80,9 +128,10 @@ class IIIFFile extends File
         if (!$resolved) {
             return 0;
         }
-        $dims = $this->getCanvasDimensions($this->normalizePage($page));
+        $page = $this->normalizePage($page);
+        $dims = $this->getCanvasDimensions($page);
         if ($dims[0] && $dims[1]) {
-            return (int) $dims[0];
+            return $dims[0];
         }
         $svc = $this->getServiceIdForPage($page);
         $info = $svc ? $this->ensureInfoJsonFor($svc) : [];
@@ -99,9 +148,10 @@ class IIIFFile extends File
         if (!$resolved) {
             return 0;
         }
-        $dims = $this->getCanvasDimensions($this->normalizePage($page));
+        $page = $this->normalizePage($page);
+        $dims = $this->getCanvasDimensions($page);
         if ($dims[0] && $dims[1]) {
-            return (int) $dims[1];
+            return $dims[1];
         }
         $svc = $this->getServiceIdForPage($page);
         $info = $svc ? $this->ensureInfoJsonFor($svc) : [];
@@ -270,9 +320,10 @@ class IIIFFile extends File
      * @return ThumbnailImage|MediaTransformError
      */
     // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType, Syde.Functions.ReturnTypeDeclaration.NoReturnType -- MediaWiki File override
-    public function transform($params, $flags = 0)
+    public function transform($params, $flags = 0): MediaTransformError|ThumbnailImage
     {
         $page = $this->normalizePage($params['page'] ?? 1);
+        $this->lastTransformPage = $page;
         $svc = $this->getServiceIdForPage($page);
         if (!$svc) {
             return new MediaTransformError(
@@ -396,7 +447,7 @@ class IIIFFile extends File
     protected function normalizePage(mixed $page): int
     {
         $pageNum = (int) $page;
-        return $pageNum >= 1 ? $pageNum : 1;
+        return max($pageNum, 1);
     }
 
     /** @return array<string, mixed>|null */
@@ -404,6 +455,16 @@ class IIIFFile extends File
     public function getResolvedManifest(): ?array
     {
         return $this->ensureResolved();
+    }
+
+    /**
+     * Page number from the most recent transform() call.
+     * Used by Hooks::onThumbnailBeforeProduceHTML to set data-iiif-page.
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- needed by hook
+    public function lastTransformPage(): int
+    {
+        return $this->lastTransformPage;
     }
 
     /**
@@ -502,9 +563,10 @@ class IIIFFile extends File
     // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- internal accessor
     protected function getProviderConfig(): array
     {
-        /** @var Repo $repo */
-        $repo = $this->repo;
-        return $repo->iiifSources();
+        if (!$this->repo instanceof Repo) {
+            return [];
+        }
+        return $this->repo->iiifSources();
     }
 
     // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- internal accessor

--- a/src/IIIFHandler.php
+++ b/src/IIIFHandler.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF;
+
+use ImageHandler;
+use MediaTransformOutput;
+use ThumbnailImage;
+
+/**
+ * MediaHandler for IIIF files.
+ *
+ * Extends ImageHandler to add `page` parameter support so that
+ * wikitext like `[[File:Foo.jpg|page=3|mini]]` works for multi-page
+ * IIIF manifests (scanned books, manuscripts, etc.).
+ *
+ * Without this handler, MediaWiki would use JpegHandler (because
+ * IIIFFile reports image/jpeg), which does not accept `page`.
+ */
+class IIIFHandler extends ImageHandler
+{
+    /**
+     * Map wikitext magic words to internal parameter names.
+     * Adding `img_page` lets the parser recognise `page=N`.
+     *
+     * @return array<string, string>
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- MediaWiki MediaHandler override
+    public function getParamMap(): array
+    {
+        return [
+            'img_width' => 'width',
+            'img_page' => 'page',
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @param mixed $value
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function validateParam($name, $value): bool
+    {
+        if ($name === 'page' && trim((string) $value) !== (string) intval($value)) {
+            // Reject non-integer page values (likely a caption).
+            return false;
+        }
+
+        return in_array($name, ['width', 'height', 'page'], true) && $value > 0;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return string|false
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function makeParamString($params): string|false
+    {
+        $page = $params['page'] ?? 1;
+        if (!isset($params['width'])) {
+            return false;
+        }
+
+        return "page{$page}-{$params['width']}px";
+    }
+
+    /**
+     * @param string $str
+     * @return array<string, mixed>|false
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function parseParamString($str): array|false
+    {
+        if (preg_match('/^page(\d+)-(\d+)px$/', $str, $matches)) {
+            return ['width' => (int) $matches[2], 'page' => (int) $matches[1]];
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound, Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    protected function getScriptParams($params): array
+    {
+        return [
+            'width' => $params['width'],
+            'page' => $params['page'] ?? 1,
+        ];
+    }
+
+    /**
+     * Produce a thumbnail for the given IIIF file.
+     *
+     * IIIFFile overrides File::transform() directly and builds the IIIF
+     * Image API URL there, so this method is normally not reached.
+     * It exists only to satisfy the abstract contract of MediaHandler.
+     *
+     * @param \File $image
+     * @param string $dstPath
+     * @param string $dstUrl
+     * @param array<string, mixed> $params
+     * @param int $flags
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType, Syde.Functions.ReturnTypeDeclaration.NoReturnType -- MediaWiki MediaHandler override
+    public function doTransform($image, $dstPath, $dstUrl, $params, $flags = 0): MediaTransformOutput
+    {
+        $width = (int) ($params['width'] ?? 0);
+        $height = (int) ($params['height'] ?? 0);
+
+        return new ThumbnailImage($image, $dstUrl, false, [
+            'width' => $width,
+            'height' => $height,
+        ]);
+    }
+
+    /**
+     * IIIF images are always remote — there is no local file to read
+     * dimensions from.  Return an empty array so that MediaWiki falls
+     * back to File::getWidth() / File::getHeight(), which IIIFFile
+     * overrides to query the manifest / info.json.
+     *
+     * @param mixed $state
+     * @param string $path
+     * @return array<string, mixed>
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound, Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function getSizeAndMetadata($state, $path): array
+    {
+        return [];
+    }
+
+    /**
+     * IIIFFile always needs rendering (thumbnail URL construction).
+     *
+     * @param \File $file
+     * @return bool
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function mustRender($file): bool
+    {
+        return true;
+    }
+
+    /**
+     * IIIF thumbnails are free — the remote service creates them.
+     *
+     * @param \File $file
+     * @return bool
+     */
+    // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- MediaWiki MediaHandler override
+    public function isExpensiveToThumbnail($file): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Fixes #38


**What is the new behavior (if this is a feature change)?**
Multi-page IIIF documents (scans of historic address books, etc.) are supported. Specific pages can be specified by using the `page=X` parameter.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
I cleaned up the MediaWiki stubs as part of this PR.