### PR TITLE
Expose IIIF documents in VE add media search

### DIFF
--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -13,6 +13,7 @@ define('MEDIATYPE_BITMAP', 'BITMAP');
 define('NS_FILE', 6);
 define('PROTO_RELATIVE', 2);
 define('PROTO_HTTPS', 1);
+define('PROTO_CURRENT', 4);
 
 /**
  * @phpstan-type RepoInfo array{name?: string, class?: string, iiifSources?: array}
@@ -25,6 +26,9 @@ class FileRepo {
     public function __construct(array $info = []) {}
 
     public function getName(): string {}
+
+    /** @return array<string, mixed> */
+    public function getInfo(): array {}
 }
 
 class MediaTransformOutput {
@@ -187,6 +191,12 @@ class RepoGroup {
      * @return File|false
      */
     public function findFile($title, array $options = []) {}
+
+    /**
+     * @param callable(FileRepo): bool $callback
+     * @param array<int, mixed> $params
+     */
+    public function forEachForeignRepo(callable $callback, array $params = []): bool {}
 }
 
 /**

--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -19,6 +19,7 @@ namespace MediaWiki;
 
 use GlobalVarConfig;
 use MediaWiki\Http\HttpRequestFactory;
+use MediaWiki\Utils\UrlUtils;
 use WANObjectCache;
 
 class MediaWikiServices {
@@ -28,6 +29,22 @@ class MediaWikiServices {
     public function getHttpRequestFactory(): HttpRequestFactory {}
     public function getRepoGroup(): \RepoGroup {}
     public function getContentLanguage(): \Language {}
+    public function getUrlUtils(): UrlUtils {}
+}
+
+class MainConfigNames {
+    public const ScriptPath = 'ScriptPath';
+    public const Script = 'Script';
+}
+
+namespace MediaWiki\Utils;
+
+class UrlUtils {
+    /**
+     * @param string $url
+     * @param int|null $defaultProto
+     */
+    public function expand(string $url, ?int $defaultProto = null): ?string {}
 }
 
 namespace MediaWiki\Http;

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -32,6 +32,7 @@ module.exports = [
 				mw: 'readonly',
 				$: 'readonly',
 				location: 'readonly',
+				MutationObserver: 'readonly',
 			},
 		},
 	},

--- a/extension.json
+++ b/extension.json
@@ -44,6 +44,18 @@
         "mediawiki.Title"
       ],
       "position": "top"
+    },
+    "ext.instantIIIF.mediaSearch": {
+      "scripts": [
+        "resources/media-search.js"
+      ],
+      "targets": [
+        "desktop",
+        "mobile"
+      ],
+      "dependencies": [
+        "mediawiki.api"
+      ]
     }
   },
   "Hooks": {

--- a/resources/media-search.js
+++ b/resources/media-search.js
@@ -1,0 +1,250 @@
+// Make IIIF files discoverable in the MediaWiki media-search UI
+// (VisualEditor's "Insert media" dialog, GalleryDialog, …).
+//
+// MediaSearchWidget queries every configured FileRepo with
+// `generator=search&gsrnamespace=6`, which goes through the local search
+// engine. IIIF files have no local wiki page and are not indexed, so the
+// search returns nothing for valid IIIF identifiers like "df_dk_0007450".
+//
+// Direct title lookup (`titles=File:<id>.jpg&prop=imageinfo`) does resolve
+// the file: ApiQueryImageInfo asks our IIIFFile repo, which fetches the
+// IIIF manifest and returns `imagerepository: "iiif"` plus imageinfo.
+//
+// This module replaces `fetchAPIresults` on the MediaSearchProvider tied
+// to the IIIF repo with a direct title lookup. The repo is identified by
+// matching `provider.apiurl` against the apiurls advertised in the
+// `wgInstantIIIFRepos` config var (set by Hooks::onBeforePageDisplay).
+( function () {
+	const repos = mw.config.get( 'wgInstantIIIFRepos' );
+	if ( ! Array.isArray( repos ) || ! repos.length ) {
+		return;
+	}
+
+	const repoByApiUrl = {};
+	const allPatterns = [];
+	repos.forEach( function ( repo ) {
+		if ( ! repo || typeof repo.apiurl !== 'string' ) {
+			return;
+		}
+		const patterns = compilePatterns( repo.idPatterns || [] );
+		repoByApiUrl[ repo.apiurl ] = { patterns };
+		allPatterns.push.apply( allPatterns, patterns );
+	} );
+
+	mw.loader
+		.using( 'mediawiki.widgets.MediaSearch' )
+		.then( patchMediaSearchProvider );
+
+	hideMisleadingUploadDateForIIIFFiles();
+
+	function patchMediaSearchProvider() {
+		const proto =
+			mw.widgets &&
+			mw.widgets.MediaSearchProvider &&
+			mw.widgets.MediaSearchProvider.prototype;
+		if ( ! proto || proto._instantIIIFPatched ) {
+			return;
+		}
+		const origFetch = proto.fetchAPIresults;
+
+		proto.fetchAPIresults = function ( howMany ) {
+			const descriptor = repoByApiUrl[ this.apiurl ];
+			if ( ! descriptor ) {
+				return origFetch.call( this, howMany );
+			}
+			return iiifTitleLookup.call( this, descriptor );
+		};
+
+		proto._instantIIIFPatched = true;
+	}
+
+	// Fetch a single virtual IIIF file by treating the typed query as an
+	// IIIF identifier. Returns the same shape as the upstream
+	// `fetchAPIresults` so MediaSearchProvider's queue can consume it.
+	function iiifTitleLookup( descriptor ) {
+		// IIIF has no fulltext search — every result fits in the first
+		// page, so the second call must report depletion.
+		if ( this.getOffset() > 0 ) {
+			this.toggleDepleted( true );
+			return emptyPromise();
+		}
+
+		// IIIF identifiers in the wild are extension-less. Strip a trailing
+		// image extension before pattern-matching so the user can type with
+		// or without one without changing the lookup.
+		const query = String( this.getUserParams().gsrsearch || '' )
+			.trim()
+			.replace( /\.(jpg|jpeg|png|gif|bmp|webp)$/i, '' );
+		if ( ! query ) {
+			this.toggleDepleted( true );
+			return emptyPromise();
+		}
+		if (
+			descriptor.patterns.length &&
+			! descriptor.patterns.some( function ( re ) {
+				return re.test( query );
+			} )
+		) {
+			this.toggleDepleted( true );
+			return emptyPromise();
+		}
+
+		const api = this.isLocal
+			? new mw.Api()
+			: new mw.ForeignApi( this.apiurl, { anonymous: true } );
+
+		const xhr = api.get( {
+			action: 'query',
+			format: 'json',
+			titles: 'File:' + query + '.jpg',
+			prop: 'imageinfo',
+			iiprop: 'dimensions|url|mediatype|extmetadata|timestamp|user',
+			iiextmetadatalanguage: this.getLang(),
+			iiurlheight: this.staticParams.iiurlheight,
+			iiurlwidth: this.staticParams.iiurlwidth,
+		} );
+
+		const provider = this;
+		const deferred = $.Deferred();
+		xhr.then(
+			function ( data ) {
+				provider.toggleDepleted( true );
+				deferred.resolve( extractIIIFResults( data ) );
+			},
+			function () {
+				provider.toggleDepleted( true );
+				deferred.resolve( [] );
+			}
+		);
+		return deferred.promise( { abort: xhr.abort } );
+	}
+
+	// Pull the imageinfo entries that the local API has flagged as IIIF.
+	// Anything else (missing files, unrelated repos) is dropped so the
+	// user only sees real IIIF matches.
+	function extractIIIFResults( data ) {
+		if ( ! data || ! data.query || ! data.query.pages ) {
+			return [];
+		}
+		const out = [];
+		Object.keys( data.query.pages ).forEach( function ( pageId ) {
+			const page = data.query.pages[ pageId ];
+			if ( ! page || page.imagerepository !== 'iiif' ) {
+				return;
+			}
+			const info = page.imageinfo && page.imageinfo[ 0 ];
+			if ( ! info ) {
+				return;
+			}
+			info.title = page.title;
+			info.index = 0;
+			out.push( info );
+		} );
+		return out;
+	}
+
+	// Convert PHP-style regex (with delimiters, e.g. `/^df_.+$/i`) into
+	// a JS RegExp. Drops PHP-only flags the engine doesn't understand.
+	function compilePatterns( raw ) {
+		const compiled = [];
+		raw.forEach( function ( pattern ) {
+			if ( typeof pattern !== 'string' || pattern === '' ) {
+				return;
+			}
+			const match = pattern.match( /^(.)([\s\S]+)\1([a-zA-Z]*)$/ );
+			let body = pattern;
+			let flags = '';
+			if ( match ) {
+				body = match[ 2 ];
+				flags = match[ 3 ].replace( /[^gimsuy]/g, '' );
+			}
+			try {
+				compiled.push( new RegExp( body, flags ) );
+			} catch {
+				// Skip patterns we can't parse — better than throwing
+				// during widget setup and blocking the whole search.
+			}
+		} );
+		return compiled;
+	}
+
+	// Strip the "Uploaded: a few seconds ago" row from VE's media-info
+	// panel for IIIF files. The IIIFFile has no real upload timestamp, so
+	// ApiQueryImageInfo falls back to wfTimestampNow() and VE renders the
+	// dialog-opening time — misleading for hotlinked remote media. The
+	// same fallback bug is already cosmetically suppressed on the file
+	// description page via Hooks::onImagePageFileHistoryLine.
+	//
+	// A MutationObserver picks up newly-rendered media-info panels (the
+	// dialog rebuilds them per selection); for any whose title matches a
+	// configured IIIF idPattern we hide every `.oo-ui-icon-clock` row.
+	// IIIF files never carry a real `DateTimeOriginal` either, so the
+	// only clock row in practice is the timestamp.
+	function hideMisleadingUploadDateForIIIFFiles() {
+		if ( ! allPatterns.length || typeof MutationObserver !== 'function' ) {
+			return;
+		}
+		const observer = new MutationObserver( function ( records ) {
+			records.forEach( function ( record ) {
+				record.addedNodes.forEach( function ( node ) {
+					if ( node.nodeType !== 1 ) {
+						return;
+					}
+					findInfoPanels( node ).forEach( maybeHideClockRows );
+				} );
+			} );
+		} );
+		observer.observe( document.body, { childList: true, subtree: true } );
+	}
+
+	function findInfoPanels( node ) {
+		const panels = [];
+		if (
+			node.matches &&
+			node.matches( '.ve-ui-mwMediaDialog-panel-imageinfo-info' )
+		) {
+			panels.push( node );
+		}
+		if ( node.querySelectorAll ) {
+			node.querySelectorAll(
+				'.ve-ui-mwMediaDialog-panel-imageinfo-info'
+			).forEach( function ( el ) {
+				panels.push( el );
+			} );
+		}
+		return panels;
+	}
+
+	function maybeHideClockRows( panel ) {
+		const titleEl = panel.querySelector(
+			'.ve-ui-mwMediaDialog-panel-imageinfo-title'
+		);
+		if ( ! titleEl ) {
+			return;
+		}
+		// VE renders titles with spaces and a capitalised first character.
+		// Convert back to the IIIF object-id shape (lowercased, underscored)
+		// before pattern-matching.
+		const id = String( titleEl.textContent || '' )
+			.trim()
+			.replace( /\s+/g, '_' )
+			.toLowerCase();
+		if ( ! id || ! allPatterns.some( ( re ) => re.test( id ) ) ) {
+			return;
+		}
+		panel
+			.querySelectorAll( '.oo-ui-icon-clock' )
+			.forEach( function ( icon ) {
+				const row = icon.closest( '.ve-ui-mwMediaInfoFieldWidget' );
+				if ( row ) {
+					row.style.display = 'none';
+				}
+			} );
+	}
+
+	function emptyPromise() {
+		return $.Deferred().resolve( [] ).promise( { abort: noop } );
+	}
+
+	function noop() {}
+} )();

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -28,6 +28,12 @@ class Hooks
     {
         $out->addModules(['ext.instantIIIF.mmvPatch']);
 
+        $iiifRepos = self::collectIIIFRepoDescriptors();
+        if ($iiifRepos !== []) {
+            $out->addJsConfigVars('wgInstantIIIFRepos', $iiifRepos);
+            $out->addModules(['ext.instantIIIF.mediaSearch']);
+        }
+
         $title = $out->getTitle();
         if ($title === null || $title->getNamespace() !== NS_FILE) {
             return;
@@ -43,6 +49,31 @@ class Hooks
         if ($providerUrl !== '') {
             $out->addJsConfigVars('wgIIIFProviderUrl', $providerUrl);
         }
+    }
+
+    /**
+     * Collect descriptors for every configured InstantIIIF repo so the
+     * client-side media-search patch can recognise them and route their
+     * search requests through a direct title lookup.
+     *
+     * @return list<array{apiurl: string, idPatterns: list<string>}>
+     */
+    private static function collectIIIFRepoDescriptors(): array
+    {
+        $descriptors = [];
+        \MediaWiki\MediaWikiServices::getInstance()
+            ->getRepoGroup()
+            // phpcs:ignore Syde.Functions.ArgumentTypeDeclaration.NoArgumentType -- forEachForeignRepo callback receives FileRepo
+            ->forEachForeignRepo(static function ($repo) use (&$descriptors): bool {
+                if ($repo instanceof Repo) {
+                    $descriptors[] = [
+                        'apiurl' => Repo::resolveLocalApiUrl(),
+                        'idPatterns' => $repo->idPatterns(),
+                    ];
+                }
+                return false;
+            });
+        return $descriptors;
     }
 
     /**

--- a/src/Repo.php
+++ b/src/Repo.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MediaWiki\Extension\InstantIIIF;
 
 use FileRepo;
+use MediaWiki\MainConfigNames;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 
 class Repo extends FileRepo
@@ -51,5 +53,60 @@ class Repo extends FileRepo
     public function iiifSources(): array
     {
         return $this->iiifSources;
+    }
+
+    /**
+     * Configured IIIF source ID patterns (PHP-style with delimiters).
+     *
+     * @return list<string>
+     */
+    public function idPatterns(): array
+    {
+        $patterns = [];
+        foreach ($this->iiifSources as $src) {
+            if (!is_array($src)) {
+                continue;
+            }
+            $pattern = $src['idPattern'] ?? null;
+            if (is_string($pattern) && $pattern !== '') {
+                $patterns[] = $pattern;
+            }
+        }
+        return $patterns;
+    }
+
+    /**
+     * Override to add an explicit `apiurl` (so the JS-side MediaSearchProvider
+     * hits a URL we can recognise) plus the `instantIIIFIdPatterns` field used
+     * by the client-side search patch to decide whether to attempt an IIIF
+     * lookup for a typed query.
+     *
+     * Without our `apiurl`, MediaResourceProvider falls back to
+     * `scriptDirUrl + '/api.php'`, which still works as an API endpoint but
+     * differs in formatting between repos and is harder to match on.
+     *
+     * @return array<string, mixed>
+     */
+    // phpcs:ignore Syde.Classes.DisallowGetterSetter.GetterFound -- MediaWiki FileRepo override
+    public function getInfo(): array
+    {
+        $info = parent::getInfo();
+        $info['apiurl'] = self::resolveLocalApiUrl();
+        $info['instantIIIFIdPatterns'] = $this->idPatterns();
+        return $info;
+    }
+
+    /**
+     * Absolute URL to this wiki's `api.php`, matching what MediaWiki's JS
+     * MediaResourceProvider would build for a local request.
+     */
+    public static function resolveLocalApiUrl(): string
+    {
+        $services = MediaWikiServices::getInstance();
+        $scriptPath = (string) $services->getMainConfig()->get(MainConfigNames::ScriptPath);
+        return (string) $services->getUrlUtils()->expand(
+            $scriptPath . '/api.php',
+            PROTO_CURRENT
+        );
     }
 }

--- a/tests/jest/media-search.test.js
+++ b/tests/jest/media-search.test.js
@@ -1,0 +1,375 @@
+/**
+ * Tests for resources/media-search.js — the client-side patch that makes
+ * IIIF files discoverable in MediaSearchWidget (VE's media insert dialog).
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const { createMwEnv } = require( './mw-mock' );
+
+function loadMediaSearch( win ) {
+	const code = fs.readFileSync(
+		path.resolve( __dirname, '../../resources/media-search.js' ),
+		'utf-8'
+	);
+	const fn = new Function(
+		'window',
+		'document',
+		'mw',
+		'$',
+		'location',
+		code
+	);
+	fn( win, win.document, win.mw, win.$, win.location );
+}
+
+// Minimal promise+abort surface to mimic the jQuery-style xhr the upstream
+// MediaSearchProvider returns. Pulled into a helper because every test
+// stubs mw.Api around it.
+function fakeXhr( data ) {
+	const p = Promise.resolve( data );
+	p.abort = jest.fn();
+	return p;
+}
+
+// Build the mw stubs MediaSearchProvider depends on inside the patch:
+// mw.Api, mw.ForeignApi, mw.widgets.MediaSearchProvider (with a real
+// fetchAPIresults we can spy on).
+function setupMediaSearchProvider( mw, opts = {} ) {
+	const apiCalls = [];
+	const apiResponse = opts.apiResponse ?? {};
+
+	function FakeApi() {
+		this.get = ( params ) => {
+			apiCalls.push( { kind: 'local', params } );
+			return fakeXhr( apiResponse );
+		};
+	}
+	function FakeForeignApi( url ) {
+		this.get = ( params ) => {
+			apiCalls.push( { kind: 'foreign', url, params } );
+			return fakeXhr( apiResponse );
+		};
+	}
+	mw.Api = FakeApi;
+	mw.ForeignApi = FakeForeignApi;
+
+	const origFetch = jest.fn( () => fakeXhr( [] ) );
+	mw.widgets = mw.widgets || {};
+	mw.widgets.MediaSearchProvider = function () {};
+	mw.widgets.MediaSearchProvider.prototype.fetchAPIresults = origFetch;
+
+	// Force mw.loader.using to resolve immediately for `mediawiki.widgets.MediaSearch`.
+	mw.loader.using = () => Promise.resolve( () => ( {} ) );
+
+	return { apiCalls, origFetch };
+}
+
+function makeProvider( mw, overrides = {} ) {
+	const provider = Object.create( mw.widgets.MediaSearchProvider.prototype );
+	const userParams = { gsrsearch: 'df_dk_0007450' };
+	const offset = { value: 0 };
+	const depleted = { value: false };
+	Object.assign(
+		provider,
+		{
+			apiurl: 'https://wiki.example.org/w/api.php',
+			isLocal: false,
+			staticParams: { iiurlheight: 200, iiurlwidth: 300 },
+			getUserParams() {
+				return userParams;
+			},
+			getOffset() {
+				return offset.value;
+			},
+			setOffset( v ) {
+				offset.value = v;
+			},
+			toggleDepleted( v ) {
+				depleted.value = v;
+			},
+			isDepleted() {
+				return depleted.value;
+			},
+			getLang() {
+				return 'de';
+			},
+		},
+		overrides
+	);
+	provider._userParams = userParams;
+	provider._offset = offset;
+	provider._depleted = depleted;
+	return provider;
+}
+
+let env;
+
+beforeEach( () => {
+	env = createMwEnv( window );
+} );
+
+describe( 'media-search.js — config gate', () => {
+	test( 'does nothing when wgInstantIIIFRepos is unset', async () => {
+		const { origFetch } = setupMediaSearchProvider( env.mw );
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const proto = env.mw.widgets.MediaSearchProvider.prototype;
+		expect( proto.fetchAPIresults ).toBe( origFetch );
+	} );
+
+	test( 'does nothing when wgInstantIIIFRepos is empty', async () => {
+		env.config.set( 'wgInstantIIIFRepos', [] );
+		const { origFetch } = setupMediaSearchProvider( env.mw );
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		expect(
+			env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults
+		).toBe( origFetch );
+	} );
+} );
+
+describe( 'media-search.js — IIIF provider routing', () => {
+	beforeEach( () => {
+		env.config.set( 'wgInstantIIIFRepos', [
+			{
+				apiurl: 'https://wiki.example.org/w/api.php',
+				idPatterns: [ '/^df_.+$/' ],
+			},
+		] );
+	} );
+
+	test( 'routes IIIF apiurl through direct title lookup and returns imageinfo', async () => {
+		const { apiCalls, origFetch } = setupMediaSearchProvider( env.mw, {
+			apiResponse: {
+				query: {
+					pages: {
+						'-1': {
+							ns: 6,
+							title: 'File:Df_dk_0007450.jpg',
+							imagerepository: 'iiif',
+							imageinfo: [
+								{
+									width: 1600,
+									height: 1324,
+									url: 'https://iiif.example/full.jpg',
+								},
+							],
+						},
+					},
+				},
+			},
+		} );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw );
+		const results =
+			await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+				provider,
+				10
+			);
+
+		expect( origFetch ).not.toHaveBeenCalled();
+		expect( apiCalls ).toHaveLength( 1 );
+		expect( apiCalls[ 0 ].kind ).toBe( 'foreign' );
+		expect( apiCalls[ 0 ].params.titles ).toBe( 'File:df_dk_0007450.jpg' );
+		expect( apiCalls[ 0 ].params.prop ).toBe( 'imageinfo' );
+
+		expect( results ).toEqual( [
+			{
+				width: 1600,
+				height: 1324,
+				url: 'https://iiif.example/full.jpg',
+				title: 'File:Df_dk_0007450.jpg',
+				index: 0,
+			},
+		] );
+		expect( provider.isDepleted() ).toBe( true );
+	} );
+
+	test( 'drops API entries that are not flagged as iiif', async () => {
+		const { apiCalls } = setupMediaSearchProvider( env.mw, {
+			apiResponse: {
+				query: {
+					pages: {
+						'-1': {
+							ns: 6,
+							title: 'File:Df_dk_0007450.jpg',
+							imagerepository: '',
+							missing: '',
+						},
+					},
+				},
+			},
+		} );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw );
+		const results =
+			await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+				provider,
+				10
+			);
+
+		expect( apiCalls ).toHaveLength( 1 );
+		expect( results ).toEqual( [] );
+	} );
+
+	test( 'strips trailing image extension before lookup so "id.jpg" still resolves', async () => {
+		const { apiCalls } = setupMediaSearchProvider( env.mw, {
+			apiResponse: {},
+		} );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw, {
+			getUserParams: () => ( { gsrsearch: 'df_dk_0007450.png' } ),
+		} );
+		await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+			provider,
+			10
+		);
+
+		// "png" should be stripped before composing the title (we re-append
+		// `.jpg` since File titles must carry an image extension).
+		expect( apiCalls[ 0 ].params.titles ).toBe( 'File:df_dk_0007450.jpg' );
+	} );
+
+	test( 'skips the lookup when the query does not match any IIIF idPattern', async () => {
+		const { apiCalls } = setupMediaSearchProvider( env.mw );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw, {
+			getUserParams: () => ( { gsrsearch: 'kornhaus' } ),
+		} );
+		const results =
+			await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+				provider,
+				10
+			);
+
+		expect( apiCalls ).toHaveLength( 0 );
+		expect( results ).toEqual( [] );
+		expect( provider.isDepleted() ).toBe( true );
+	} );
+
+	test( 'falls back to the original fetch for non-IIIF providers (Commons, local)', async () => {
+		const { origFetch } = setupMediaSearchProvider( env.mw );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw, {
+			apiurl: 'https://commons.wikimedia.org/w/api.php',
+		} );
+		await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+			provider,
+			10
+		);
+
+		expect( origFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'reports depletion on subsequent calls so the queue does not paginate forever', async () => {
+		setupMediaSearchProvider( env.mw, { apiResponse: {} } );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw );
+		provider.setOffset( 10 );
+		const results =
+			await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+				provider,
+				10
+			);
+
+		expect( results ).toEqual( [] );
+		expect( provider.isDepleted() ).toBe( true );
+	} );
+
+	test( 'hides the timestamp row in VE media-info panels for IIIF titles', async () => {
+		setupMediaSearchProvider( env.mw );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		document.body.innerHTML = `
+			<div class="ve-ui-mwMediaDialog-panel-imageinfo-info">
+				<div class="ve-ui-mwMediaDialog-panel-imageinfo-title">Df dk 0007450</div>
+				<div class="ve-ui-mwMediaDialog-panel-imageinfo-details">
+					<div class="ve-ui-mwMediaInfoFieldWidget" id="row-clock">
+						<span class="oo-ui-icon-clock"></span>
+						Hochgeladen: vor ein paar Sekunden
+					</div>
+					<div class="ve-ui-mwMediaInfoFieldWidget" id="row-info">
+						<span class="oo-ui-icon-info"></span>
+						Weitere Informationen
+					</div>
+				</div>
+			</div>
+		`;
+
+		await new Promise( ( r ) => setTimeout( r, 50 ) );
+
+		expect( document.getElementById( 'row-clock' ).style.display ).toBe(
+			'none'
+		);
+		expect( document.getElementById( 'row-info' ).style.display ).toBe(
+			''
+		);
+	} );
+
+	test( 'does not hide the timestamp row for non-IIIF titles (Commons hit)', async () => {
+		setupMediaSearchProvider( env.mw );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		document.body.innerHTML = `
+			<div class="ve-ui-mwMediaDialog-panel-imageinfo-info">
+				<div class="ve-ui-mwMediaDialog-panel-imageinfo-title">Kornhaus Burgdorf</div>
+				<div class="ve-ui-mwMediaDialog-panel-imageinfo-details">
+					<div class="ve-ui-mwMediaInfoFieldWidget" id="row-clock">
+						<span class="oo-ui-icon-clock"></span>
+						Hochgeladen: vor 5 Jahren
+					</div>
+				</div>
+			</div>
+		`;
+
+		await new Promise( ( r ) => setTimeout( r, 50 ) );
+
+		expect( document.getElementById( 'row-clock' ).style.display ).toBe(
+			''
+		);
+	} );
+
+	test( 'uses mw.Api (not ForeignApi) when the provider is flagged local', async () => {
+		const { apiCalls } = setupMediaSearchProvider( env.mw, {
+			apiResponse: {},
+		} );
+
+		loadMediaSearch( window );
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
+
+		const provider = makeProvider( env.mw, { isLocal: true } );
+		await env.mw.widgets.MediaSearchProvider.prototype.fetchAPIresults.call(
+			provider,
+			10
+		);
+
+		expect( apiCalls[ 0 ].kind ).toBe( 'local' );
+	} );
+} );

--- a/tests/jest/mw-mock.js
+++ b/tests/jest/mw-mock.js
@@ -57,6 +57,41 @@ function createMwEnv( win ) {
 		return wrap;
 	}
 
+	// Minimal jQuery Deferred stand-in. Production code uses jQuery's
+	// Deferred to make promises that also expose `.abort()`. Tests don't
+	// care about chaining semantics — just that the patch can wrap an
+	// eventually-resolved value into a thenable carrying `.abort`.
+	jQueryFactory.Deferred = function () {
+		let resolveFn;
+		let rejectFn;
+		const native = new Promise( ( resolve, reject ) => {
+			resolveFn = resolve;
+			rejectFn = reject;
+		} );
+		const dfd = {
+			resolve( v ) {
+				resolveFn( v );
+				return dfd;
+			},
+			reject( e ) {
+				rejectFn( e );
+				return dfd;
+			},
+			promise( extras ) {
+				return Object.assign(
+					Object.create( native ),
+					{
+						then: native.then.bind( native ),
+						catch: native.catch.bind( native ),
+						finally: native.finally.bind( native ),
+					},
+					extras || {}
+				);
+			},
+		};
+		return dfd;
+	};
+
 	/**
 	 * Trigger a jQuery-style event on document (used by mmv-metadata).
 	 * @param {string} eventName

--- a/tests/phpunit/Unit/HooksTest.php
+++ b/tests/phpunit/Unit/HooksTest.php
@@ -7,6 +7,7 @@ namespace MediaWiki\Extension\InstantIIIF\Tests\Unit;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\InstantIIIF\Hooks;
 use MediaWiki\Extension\InstantIIIF\IIIFFile;
+use MediaWiki\Extension\InstantIIIF\Repo;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\ImageHistoryList;
 use MediaWiki\Page\ImagePage;
@@ -104,6 +105,80 @@ class HooksTest extends TestCase
         Hooks::onBeforePageDisplay($out, $skin);
 
         self::assertContains('ext.instantIIIF.mmvPatch', $out->modules);
+    }
+
+    public function testOnBeforePageDisplayAddsMediaSearchModuleWhenIIIFRepoIsConfigured(): void
+    {
+        $out = new OutputPage();
+        $skin = new Skin();
+
+        $iiifRepo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'directory' => '/tmp/iiif',
+            'iiifSources' => [
+                ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+                ['id' => 'slub', 'idPattern' => '/^([0-9].+)$/'],
+            ],
+        ]);
+
+        $repoGroup = $this->createMock(\RepoGroup::class);
+        $repoGroup->method('forEachForeignRepo')
+            ->willReturnCallback(static function (callable $cb) use ($iiifRepo): bool {
+                $cb($iiifRepo);
+                return false;
+            });
+        MediaWikiServices::$mockRepoGroup = $repoGroup;
+
+        Hooks::onBeforePageDisplay($out, $skin);
+
+        self::assertContains('ext.instantIIIF.mediaSearch', $out->modules);
+        self::assertArrayHasKey('wgInstantIIIFRepos', $out->jsConfigVars);
+        self::assertSame(
+            [[
+                'apiurl' => 'https://wiki.example.org/w/api.php',
+                'idPatterns' => ['/^(df_.+)$/', '/^([0-9].+)$/'],
+            ]],
+            $out->jsConfigVars['wgInstantIIIFRepos']
+        );
+    }
+
+    public function testOnBeforePageDisplaySkipsMediaSearchModuleWithoutIIIFRepo(): void
+    {
+        $out = new OutputPage();
+        $skin = new Skin();
+
+        $repoGroup = $this->createMock(\RepoGroup::class);
+        // forEachForeignRepo runs the callback with non-IIIF repos —
+        // simulated by simply not invoking it.
+        $repoGroup->method('forEachForeignRepo')->willReturn(false);
+        MediaWikiServices::$mockRepoGroup = $repoGroup;
+
+        Hooks::onBeforePageDisplay($out, $skin);
+
+        self::assertNotContains('ext.instantIIIF.mediaSearch', $out->modules);
+        self::assertArrayNotHasKey('wgInstantIIIFRepos', $out->jsConfigVars);
+    }
+
+    public function testOnBeforePageDisplaySkipsNonIIIFForeignRepos(): void
+    {
+        $out = new OutputPage();
+        $skin = new Skin();
+
+        $foreignNonIIIF = new \FileRepo(['name' => 'wikimediacommons']);
+
+        $repoGroup = $this->createMock(\RepoGroup::class);
+        $repoGroup->method('forEachForeignRepo')
+            ->willReturnCallback(static function (callable $cb) use ($foreignNonIIIF): bool {
+                $cb($foreignNonIIIF);
+                return false;
+            });
+        MediaWikiServices::$mockRepoGroup = $repoGroup;
+
+        Hooks::onBeforePageDisplay($out, $skin);
+
+        self::assertNotContains('ext.instantIIIF.mediaSearch', $out->modules);
+        self::assertArrayNotHasKey('wgInstantIIIFRepos', $out->jsConfigVars);
     }
 
     public function testOnBeforePageDisplayPassesProviderUrlOnFilePage(): void

--- a/tests/phpunit/Unit/RepoTest.php
+++ b/tests/phpunit/Unit/RepoTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Tests\Unit;
+
+use MediaWiki\Extension\InstantIIIF\Repo;
+use MediaWiki\MediaWikiServices;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Repo: idPatterns(), getInfo() with apiurl/instantIIIFIdPatterns
+ * fields consumed by the JS-side media-search patch.
+ */
+#[CoversClass(Repo::class)]
+class RepoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        MediaWikiServices::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        MediaWikiServices::reset();
+    }
+
+    private function makeRepo(array $iiifSources): Repo
+    {
+        return new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'directory' => '/tmp/iiif',
+            'iiifSources' => $iiifSources,
+        ]);
+    }
+
+    public function testIdPatternsCollectsEverySource(): void
+    {
+        $repo = $this->makeRepo([
+            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+            ['id' => 'slub', 'idPattern' => '/^([0-9].+)$/'],
+            ['id' => 'bsb', 'idPattern' => '/^(bsb[0-9].+)$/'],
+        ]);
+
+        self::assertSame(
+            ['/^(df_.+)$/', '/^([0-9].+)$/', '/^(bsb[0-9].+)$/'],
+            $repo->idPatterns()
+        );
+    }
+
+    public function testIdPatternsSkipsSourcesWithoutPattern(): void
+    {
+        $repo = $this->makeRepo([
+            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+            ['id' => 'noPattern'],
+            ['id' => 'emptyPattern', 'idPattern' => ''],
+            'malformedNonArrayEntry',
+        ]);
+
+        self::assertSame(['/^(df_.+)$/'], $repo->idPatterns());
+    }
+
+    public function testGetInfoExposesApiUrlAndPatternsForJs(): void
+    {
+        $repo = $this->makeRepo([
+            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+        ]);
+
+        $info = $repo->getInfo();
+
+        self::assertArrayHasKey('apiurl', $info);
+        self::assertSame('https://wiki.example.org/w/api.php', $info['apiurl']);
+
+        self::assertArrayHasKey('instantIIIFIdPatterns', $info);
+        self::assertSame(['/^(df_.+)$/'], $info['instantIIIFIdPatterns']);
+    }
+
+    public function testGetInfoPreservesParentInfo(): void
+    {
+        $repo = $this->makeRepo([
+            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+        ]);
+
+        $info = $repo->getInfo();
+
+        // Parent FileRepo::getInfo() (stubbed) returns `name`. The override
+        // must extend rather than replace the parent payload.
+        self::assertSame('iiif', $info['name'] ?? null);
+    }
+
+    public function testGetInfoEmptyPatternsForRepoWithoutSources(): void
+    {
+        $repo = $this->makeRepo([]);
+
+        $info = $repo->getInfo();
+
+        self::assertSame([], $info['instantIIIFIdPatterns']);
+    }
+}

--- a/tests/phpunit/stubs/global-classes.php
+++ b/tests/phpunit/stubs/global-classes.php
@@ -22,6 +22,14 @@ if (!class_exists(FileRepo::class)) {
         {
             return $this->info['name'] ?? '';
         }
+
+        /** @return array<string, mixed> */
+        public function getInfo(): array
+        {
+            return [
+                'name' => $this->getName(),
+            ];
+        }
     }
 }
 
@@ -304,14 +312,25 @@ if (!class_exists(StatusValue::class)) {
 if (!class_exists(GlobalVarConfig::class)) {
     class GlobalVarConfig
     {
+        /** @var array<string, mixed> */
+        public array $overrides = [];
+
         public function get(string $name): mixed
         {
+            if (array_key_exists($name, $this->overrides)) {
+                return $this->overrides[$name];
+            }
             return match ($name) {
                 'InstantIIIFDefaultTimeout' => 5,
+                'ScriptPath' => '/w',
                 default => null,
             };
         }
     }
+}
+
+if (!defined('PROTO_CURRENT')) {
+    define('PROTO_CURRENT', 4);
 }
 
 if (!class_exists(WANObjectCache::class)) {
@@ -383,6 +402,11 @@ if (!class_exists(RepoGroup::class)) {
     class RepoGroup
     {
         public function findFile($title, array $options = [])
+        {
+            return false;
+        }
+
+        public function forEachForeignRepo(callable $callback, array $params = []): bool
         {
             return false;
         }

--- a/tests/phpunit/stubs/mediawiki-namespaced.php
+++ b/tests/phpunit/stubs/mediawiki-namespaced.php
@@ -94,6 +94,12 @@ namespace MediaWiki {
             /** @var \RepoGroup|null */
             public static $mockRepoGroup = null;
 
+            /** @var Utils\UrlUtils|null */
+            public static ?Utils\UrlUtils $mockUrlUtils = null;
+
+            /** @var \GlobalVarConfig|null */
+            public static ?\GlobalVarConfig $mockMainConfig = null;
+
             public static function getInstance(): self
             {
                 if (self::$instance === null) {
@@ -106,6 +112,8 @@ namespace MediaWiki {
             {
                 self::$instance = null;
                 self::$mockRepoGroup = null;
+                self::$mockUrlUtils = null;
+                self::$mockMainConfig = null;
             }
 
             public function getRepoGroup(): \RepoGroup
@@ -118,6 +126,9 @@ namespace MediaWiki {
 
             public function getMainConfig(): \GlobalVarConfig
             {
+                if (self::$mockMainConfig !== null) {
+                    return self::$mockMainConfig;
+                }
                 return new \GlobalVarConfig();
             }
 
@@ -131,12 +142,45 @@ namespace MediaWiki {
                 return new Http\HttpRequestFactory();
             }
 
+            public function getUrlUtils(): Utils\UrlUtils
+            {
+                if (self::$mockUrlUtils !== null) {
+                    return self::$mockUrlUtils;
+                }
+                return new Utils\UrlUtils();
+            }
+
             /** Override-able stub so tests can set the wiki's content language. */
             public static string $mockContentLanguageCode = 'en';
 
             public function getContentLanguage(): \Language
             {
                 return new \Language(self::$mockContentLanguageCode);
+            }
+        }
+    }
+
+    if (!class_exists(MainConfigNames::class)) {
+        class MainConfigNames
+        {
+            public const ScriptPath = 'ScriptPath';
+            public const Script = 'Script';
+        }
+    }
+}
+
+// ─── MediaWiki\Utils ──────────────────────────────────────────────
+
+namespace MediaWiki\Utils {
+    if (!class_exists(UrlUtils::class)) {
+        class UrlUtils
+        {
+            public function expand(string $url, ?int $defaultProto = null): ?string
+            {
+                if (preg_match('~^https?://~', $url)) {
+                    return $url;
+                }
+                return 'https://wiki.example.org' . $url;
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Fixes #2 


**What is the new behavior (if this is a feature change)?**
Searching for files from an InstantIIIF repository in the VisualEditor's "Insert" → "Images and media" dialog returns results for IIIF documents (matching the `idPattern` config value).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
