### PR TITLE
Run Codecov snapshot uploads on push to `main`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,12 @@ on:
       - 'tests/phpunit/Integration/**'
       - 'tests/phpunit/Fixtures/**'
       - 'phpunit.integration.xml.dist'
+  # Also run on every push to main so Codecov's snapshot of the
+  # default branch always carries a fresh integration-coverage
+  # upload, even when the PR that just merged didn't touch any
+  # PHP / integration-test files.
+  push:
+    branches: [main]
 
 jobs:
   phpunit-mwit:

--- a/.github/workflows/quality-assurance-js.yml
+++ b/.github/workflows/quality-assurance-js.yml
@@ -5,6 +5,11 @@ on:
       - '**.js'
       - 'package.json'
       - 'package-lock.json'
+  # Also run on every push to main so Codecov's snapshot of the
+  # default branch always carries a fresh JS-unit coverage upload,
+  # even when the PR that just merged didn't touch any JS files.
+  push:
+    branches: [main]
 jobs:
   unit-tests-js:
     uses: inpsyde/reusable-workflows/.github/workflows/tests-unit-js.yml@feature/188-codecov-support-unit-tests-php

--- a/.github/workflows/quality-assurance-php.yml
+++ b/.github/workflows/quality-assurance-php.yml
@@ -6,6 +6,11 @@ on:
       - 'composer.*'
       - 'phpcs.*'
       - 'phpstan.*'
+  # Also run on every push to main so Codecov's snapshot of the
+  # default branch always carries a fresh PHP-unit coverage upload,
+  # even when the PR that just merged didn't touch any PHP files.
+  push:
+    branches: [main]
 jobs:
   lint-php:
     uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


**What is the current behavior?** (You can also link to an open issue here)
For the `main` branch, Codecov only shows the latest snapshot of what was uploaded in the PR merged last, e.g., a JS-only coverage report.


**What is the new behavior (if this is a feature change)?**
Add `push: branches: [main]` trigger to all Codecov-related workflows. Every merge then triggers all three, regardless of what the PR touched, and the main commit on Codecov always has the complete picture.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
