### PR TITLE
Don't add `.jpg` to images inserted via VisualEditor

### DIFF
--- a/.docker/LocalSettings.php
+++ b/.docker/LocalSettings.php
@@ -52,7 +52,7 @@ wfLoadExtension( 'InstantIIIF' );
 
 # Configure IIIF provider pointing to the mock server.
 $wgForeignFileRepos[] = [
-    'name' => 'iiif-test',
+    'name' => 'iiif',
     'class' => \MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo::class,
     'directory' => '/tmp/iiif-repo',
     'hashLevels' => 0,

--- a/.docker/LocalSettings.php
+++ b/.docker/LocalSettings.php
@@ -47,6 +47,16 @@ wfLoadSkin( 'Vector' );
 wfLoadExtension( 'MultimediaViewer' );
 $wgMediaViewerEnableByDefault = true;
 
+# Enable VisualEditor. VE's "Insert media" dialog is the path that
+# exercises resources/media-search.js, # so it must be present for the
+# media-search e2e tests.
+wfLoadExtension( 'VisualEditor' );
+$wgDefaultUserOptions['visualeditor-enable'] = 1;
+$wgVisualEditorEnableWikitext = true;
+# Suppress the one-time "beta welcome" dialog so it doesn't intercept the
+# media-insert dialog in e2e tests.
+$wgVisualEditorShowBetaWelcome = false;
+
 # Load InstantIIIF.
 wfLoadExtension( 'InstantIIIF' );
 

--- a/.docker/LocalSettings.php
+++ b/.docker/LocalSettings.php
@@ -69,6 +69,7 @@ $wgForeignFileRepos[] = [
     'iiifSources' => [
         [
             'id' => 'deutsche-fotothek',
+            'idPattern' => '/^df_[a-z0-9_-]+$/i',
             'manifestPattern' => 'http://iiif-mock:8111/iiif/2/$1/manifest.json',
         ],
     ],

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ Once the extension is loaded, IIIF identifiers also resolve in VisualEditor's "I
 
 Each entry in `iiifSources`:
 
-| Key               | Required | Description                                                                                                                                                                                                                                     |
-|-------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`              | yes      | Short provider identifier. Use one of the officially-supported IDs above to enable provider-specific fallbacks; any other string is fine for unsupported providers.                                                                             |
-| `manifestPattern` | yes      | URL of the IIIF manifest. `$1` is replaced with the file identifier.                                                                                                                                                                            |
-| `idPattern`       | no       | PHP regex (**with delimiters**, e.g. `/^df_[a-z0-9_-]+$/i`) constraining which file titles route to this source. When omitted, the source is treated as a catch-all and tried for every identifier — useful when only one source is configured. |
+| Key               | Required | Description                                                                                                                                                                                                                                                                                                           |
+|-------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`              | yes      | Short provider identifier. Use one of the officially-supported IDs above to enable provider-specific fallbacks; any other string is fine for unsupported providers.                                                                                                                                                   |
+| `manifestPattern` | yes      | URL of the IIIF manifest. `$1` is replaced with the file identifier.                                                                                                                                                                                                                                                  |
+| `idPattern`       | yes      | PHP regex (**with delimiters**, e.g. `/^df_[a-z0-9_-]+$/i`) constraining which file titles route to this source. Required: it scopes which identifiers are fetched from this provider, so a manifest request is never fired for ids that belong elsewhere. For a single catch-all source, use `/./` (matches any id). |
 
 Optional globals:
 

--- a/extension.json
+++ b/extension.json
@@ -68,6 +68,18 @@
         "ext.instantIIIF.title"
       ]
     },
+    "ext.instantIIIF.veMediaInsert": {
+      "scripts": [
+        "resources/ve-media-insert.js"
+      ],
+      "targets": [
+        "desktop",
+        "mobile"
+      ],
+      "dependencies": [
+        "ext.instantIIIF.title"
+      ]
+    },
     "ext.instantIIIF.filePage": {
       "styles": [
         "resources/file-page.css"

--- a/extension.json
+++ b/extension.json
@@ -90,6 +90,13 @@
       ]
     }
   },
+  "attributes": {
+    "VisualEditor": {
+      "PluginModules": [
+        "ext.instantIIIF.veMediaInsert"
+      ]
+    }
+  },
   "ServiceWiringFiles": [
     "src/ServiceWiring.php"
   ],

--- a/resources/media-search.js
+++ b/resources/media-search.js
@@ -138,6 +138,12 @@
 			}
 			info.title = page.title;
 			info.index = 0;
+			// Flag the result as ours so ve-media-insert.js can strip the
+			// spoofed `.jpg` when VE turns it into the inserted node. The
+			// spoofed title must stay on `info.title` here — VE filters the
+			// media-search grid by file extension, so dropping it would hide
+			// the result entirely.
+			info.isInstantIIIF = true;
 			out.push( info );
 		} );
 		return out;

--- a/resources/ve-media-insert.js
+++ b/resources/ve-media-insert.js
@@ -11,6 +11,11 @@
 //
 // The `.jpg` the MMV overlay needs on rendered thumbnails is re-added
 // independently by the ThumbnailBeforeProduceHTML hook (data-iiif-title).
+//
+// Registered as a VisualEditorPluginModules attribute (extension.json), so VE
+// loads and runs this only while the editor is initialising — before the user
+// can open the media dialog. We still wait on ext.visualEditor.mwimage (which
+// defines ve.ui.MWMediaDialog) since plugin-module load order isn't guaranteed.
 ( function () {
 	'use strict';
 
@@ -18,14 +23,7 @@
 	// the ext.instantIIIF.title dependency.
 	const iiifTitle = window.iiifTitle;
 
-	// ve.ui.MWMediaDialog lives in the ext.visualEditor.mwimage module, which
-	// is only present once the editor has activated. Patch then — before the
-	// user can open the media dialog.
-	mw.hook( 've.activationComplete' ).add( function () {
-		mw.loader
-			.using( 'ext.visualEditor.mwimage' )
-			.then( patch, function () {} );
-	} );
+	mw.loader.using( 'ext.visualEditor.mwimage' ).then( patch, function () {} );
 
 	function patch() {
 		const ve = window.ve;

--- a/resources/ve-media-insert.js
+++ b/resources/ve-media-insert.js
@@ -1,0 +1,71 @@
+// Strip the spoofed `.jpg` from IIIF files when VisualEditor's "Insert media"
+// dialog turns a chosen search result into the inserted node.
+//
+// VE needs the spoofed `.jpg` to *display* the result in the media-search grid
+// (it filters results by file extension — see media-search.js, which flags
+// each IIIF result with `isInstantIIIF`). The inserted wikitext, however, must
+// be extension-less so VE-inserted embeds match hand-written `[[File:<id>]]`
+// wikitext. ve.ui.MWMediaDialog#confirmSelectedImage builds the node's
+// `resource`/`href` from `info.title`, so we un-spoof that title there — only
+// for flagged IIIF results, leaving Commons/local `.jpg` files untouched.
+//
+// The `.jpg` the MMV overlay needs on rendered thumbnails is re-added
+// independently by the ThumbnailBeforeProduceHTML hook (data-iiif-title).
+( function () {
+	'use strict';
+
+	// Shared spoof/unspoof helpers (mirrored in src/IIIFTitle.php). Loaded via
+	// the ext.instantIIIF.title dependency.
+	const iiifTitle = window.iiifTitle;
+
+	// ve.ui.MWMediaDialog lives in the ext.visualEditor.mwimage module, which
+	// is only present once the editor has activated. Patch then — before the
+	// user can open the media dialog.
+	mw.hook( 've.activationComplete' ).add( function () {
+		mw.loader
+			.using( 'ext.visualEditor.mwimage' )
+			.then( patch, function () {} );
+	} );
+
+	function patch() {
+		const ve = window.ve;
+		if (
+			! ve ||
+			! ve.ui ||
+			! ve.ui.MWMediaDialog ||
+			ve.ui.MWMediaDialog.prototype._instantIIIFPatched
+		) {
+			return;
+		}
+		const proto = ve.ui.MWMediaDialog.prototype;
+		const origConfirm = proto.confirmSelectedImage;
+
+		proto.confirmSelectedImage = function () {
+			const info = this.selectedImageInfo;
+			if ( ! info || ! info.isInstantIIIF ) {
+				return origConfirm.apply( this, arguments );
+			}
+			// confirmSelectedImage (synchronously) bakes `info.title` into the
+			// node's resource/href. Un-spoof it across that call so the embed
+			// serialises extension-less, then restore the original so the
+			// cached search-result object VE still holds keeps the spoofed
+			// title it needs to render in the results grid.
+			const origTitle = info.title;
+			const origCanonical = info.canonicaltitle;
+			if ( origTitle ) {
+				info.title = iiifTitle.unspoof( origTitle );
+			}
+			if ( origCanonical ) {
+				info.canonicaltitle = iiifTitle.unspoof( origCanonical );
+			}
+			try {
+				return origConfirm.apply( this, arguments );
+			} finally {
+				info.title = origTitle;
+				info.canonicaltitle = origCanonical;
+			}
+		};
+
+		proto._instantIIIFPatched = true;
+	}
+} )();

--- a/src/Infrastructure/MediaWiki/HookHandler.php
+++ b/src/Infrastructure/MediaWiki/HookHandler.php
@@ -45,7 +45,7 @@ class HookHandler implements
         $iiifRepos = $this->collectIIIFRepoDescriptors();
         if ($iiifRepos !== []) {
             $out->addJsConfigVars('wgInstantIIIFRepos', $iiifRepos);
-            $out->addModules(['ext.instantIIIF.mediaSearch', 'ext.instantIIIF.veMediaInsert']);
+            $out->addModules(['ext.instantIIIF.mediaSearch']);
         }
 
         $title = $out->getTitle();

--- a/src/Infrastructure/MediaWiki/HookHandler.php
+++ b/src/Infrastructure/MediaWiki/HookHandler.php
@@ -45,7 +45,7 @@ class HookHandler implements
         $iiifRepos = $this->collectIIIFRepoDescriptors();
         if ($iiifRepos !== []) {
             $out->addJsConfigVars('wgInstantIIIFRepos', $iiifRepos);
-            $out->addModules(['ext.instantIIIF.mediaSearch']);
+            $out->addModules(['ext.instantIIIF.mediaSearch', 'ext.instantIIIF.veMediaInsert']);
         }
 
         $title = $out->getTitle();

--- a/src/Infrastructure/MediaWiki/IIIFFile.php
+++ b/src/Infrastructure/MediaWiki/IIIFFile.php
@@ -573,7 +573,11 @@ class IIIFFile extends File
      */
     private function tryProvider(array $src, string $objId): ?array
     {
-        if (isset($src['idPattern']) && !preg_match($src['idPattern'], $objId)) {
+        // A source must declare an idPattern (enforced at Repo construction)
+        // and the id must match it. Bail before any HTTP fetch otherwise, so
+        // a provider is only queried for ids that belong to it.
+        $pattern = $src['idPattern'] ?? null;
+        if (!is_string($pattern) || $pattern === '' || !preg_match($pattern, $objId)) {
             return null;
         }
         $manifestUrl = str_replace('$1', $objId, $src['manifestPattern'] ?? '');

--- a/src/Infrastructure/MediaWiki/Repo.php
+++ b/src/Infrastructure/MediaWiki/Repo.php
@@ -29,7 +29,41 @@ class Repo extends FileRepo
                 ->get(MainConfigNames::UploadDirectory);
         }
         parent::__construct($info);
-        $this->iiifSources = $info['iiifSources'] ?? [];
+        $sources = $info['iiifSources'] ?? [];
+        self::assertSourcesHaveIdPattern($sources);
+        $this->iiifSources = $sources;
+    }
+
+    /**
+     * Every configured IIIF source must declare a non-empty `idPattern`.
+     *
+     * The pattern scopes which identifiers route to a source. Without one a
+     * source would match every identifier, so the resolver would fire an HTTP
+     * manifest request to it for ids that belong to another provider (or to
+     * no provider at all). Requiring it keeps `IIIFFile::tryProvider()` from
+     * making those needless calls. A single-provider setup that genuinely
+     * wants to accept anything can use a catch-all regex such as `/./`.
+     *
+     * @param array<int, mixed> $sources
+     * @throws \InvalidArgumentException when a source omits a valid idPattern.
+     */
+    private static function assertSourcesHaveIdPattern(array $sources): void
+    {
+        foreach ($sources as $index => $src) {
+            $pattern = is_array($src) ? ($src['idPattern'] ?? null) : null;
+            if (is_string($pattern) && $pattern !== '') {
+                continue;
+            }
+            $id = is_array($src) ? ($src['id'] ?? null) : null;
+            $label = is_string($id) && $id !== '' ? "'{$id}'" : "#{$index}";
+            throw new \InvalidArgumentException(
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal config-error message, never rendered as web output
+                "InstantIIIF: iiifSources entry {$label} must define a non-empty "
+                . "'idPattern' (a PHP regex with delimiters, e.g. '/^df_/'). It "
+                . 'scopes which identifiers route to the source and prevents '
+                . 'needless IIIF manifest fetches; use \'/./\' to accept any id.'
+            );
+        }
     }
 
     /**

--- a/src/Infrastructure/MediaWiki/Repo.php
+++ b/src/Infrastructure/MediaWiki/Repo.php
@@ -102,13 +102,7 @@ class Repo extends FileRepo
     {
         $patterns = [];
         foreach ($this->iiifSources as $src) {
-            if (!is_array($src)) {
-                continue;
-            }
-            $pattern = $src['idPattern'] ?? null;
-            if (is_string($pattern) && $pattern !== '') {
-                $patterns[] = $pattern;
-            }
+            $patterns[] = (string) $src['idPattern'];
         }
         return $patterns;
     }

--- a/src/Infrastructure/MediaWiki/SpecialInstantIIIFInspect.php
+++ b/src/Infrastructure/MediaWiki/SpecialInstantIIIFInspect.php
@@ -160,9 +160,11 @@ class SpecialInstantIIIFInspect extends SpecialPage
             'iiifSources' => [
                 [
                     'id' => $providerId !== '' ? $providerId : 'inspector',
-                    // No idPattern — catch-all so our synthetic title
-                    // resolves. The URL is used verbatim because it
-                    // doesn't contain $1.
+                    // Catch-all pattern so our synthetic title resolves
+                    // regardless of its id (idPattern is required on every
+                    // source; '/./' matches any non-empty id). The URL is
+                    // used verbatim because it doesn't contain $1.
+                    'idPattern' => '/./',
                     'manifestPattern' => $manifestUrl,
                 ],
             ],

--- a/tests/jest/media-search.test.js
+++ b/tests/jest/media-search.test.js
@@ -170,6 +170,10 @@ describe( 'media-search.js — IIIF provider routing', () => {
 				url: 'https://iiif.example/full.jpg',
 				title: 'File:Df_dk_0007450.jpg',
 				index: 0,
+				// Flag consumed by ve-media-insert.js to strip the spoofed
+				// `.jpg` from the inserted node (the result title stays
+				// spoofed so VE displays it).
+				isInstantIIIF: true,
 			},
 		] );
 		expect( provider.isDepleted() ).toBe( true );

--- a/tests/jest/mw-mock.js
+++ b/tests/jest/mw-mock.js
@@ -288,4 +288,19 @@ function loadMediaSearch( win ) {
 	loadResource( win, '../../resources/media-search.js' );
 }
 
-module.exports = { createMwEnv, loadMmvPatch, loadMediaSearch };
+/**
+ * Load and execute resources/ve-media-insert.js. Call after createMwEnv().
+ * Loads the shared iiif-title helpers first.
+ * @param {Window} win
+ */
+function loadVeMediaInsert( win ) {
+	loadResource( win, '../../resources/iiif-title.js' );
+	loadResource( win, '../../resources/ve-media-insert.js' );
+}
+
+module.exports = {
+	createMwEnv,
+	loadMmvPatch,
+	loadMediaSearch,
+	loadVeMediaInsert,
+};

--- a/tests/jest/ve-media-insert.test.js
+++ b/tests/jest/ve-media-insert.test.js
@@ -2,6 +2,11 @@
  * Tests for resources/ve-media-insert.js — the patch that strips the spoofed
  * `.jpg` from IIIF files when VisualEditor's media dialog turns a chosen
  * search result into the inserted node (ve.ui.MWMediaDialog#confirmSelectedImage).
+ *
+ * The module is loaded as a VisualEditorPluginModules attribute, so its IIFE
+ * runs while VE initialises: it resolves ext.visualEditor.mwimage and then
+ * patches the dialog prototype. The tests load the module and flush microtasks
+ * to let that mw.loader.using().then( patch ) chain settle.
  */
 
 'use strict';
@@ -47,7 +52,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		const { MWMediaDialog, seen } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		const dialog = new MWMediaDialog();
@@ -77,7 +81,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		const { MWMediaDialog, seen } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		const dialog = new MWMediaDialog();
@@ -93,7 +96,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		const { MWMediaDialog, seen } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		const dialog = new MWMediaDialog();
@@ -107,7 +109,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		const { MWMediaDialog, seen } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		const dialog = new MWMediaDialog();
@@ -125,7 +126,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		const { MWMediaDialog, seen } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		const dialog = new MWMediaDialog();
@@ -141,40 +141,34 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 		expect( seen[ 0 ].canonicaltitle ).toBe( 'File:Bsb11610364' );
 	} );
 
-	test( 'does not re-patch the prototype on a second activation', async () => {
+	test( 'does not re-patch the prototype when loaded twice', async () => {
 		const { MWMediaDialog } = installFakeVe( window );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 		const patched = MWMediaDialog.prototype.confirmSelectedImage;
 
-		// Second activation must short-circuit on the _instantIIIFPatched guard.
-		env.mw.hook( 've.activationComplete' ).fire();
+		// A second module load (e.g. VE re-initialised) must short-circuit on
+		// the _instantIIIFPatched guard rather than wrap the wrapper.
+		loadVeMediaInsert( window );
 		await flush();
 
 		expect( MWMediaDialog.prototype.confirmSelectedImage ).toBe( patched );
 	} );
 
 	test( 'does nothing when ve.ui.MWMediaDialog is unavailable', async () => {
-		// ve present but no ui/dialog (e.g. a stripped editor bundle).
+		// ve present but no dialog class (e.g. a stripped editor bundle).
 		window.ve = { ui: {} };
 
 		loadVeMediaInsert( window );
-		expect( () => {
-			env.mw.hook( 've.activationComplete' ).fire();
-		} ).not.toThrow();
 		await flush();
 
 		expect( window.ve.ui.MWMediaDialog ).toBeUndefined();
 	} );
 
 	test( 'does nothing when ve is absent entirely', async () => {
-		// No window.ve at all.
+		// No window.ve at all — patch guard returns without throwing.
 		loadVeMediaInsert( window );
-		expect( () => {
-			env.mw.hook( 've.activationComplete' ).fire();
-		} ).not.toThrow();
 		await flush();
 
 		expect( window.ve ).toBeUndefined();
@@ -187,7 +181,6 @@ describe( 've-media-insert.js — confirmSelectedImage patch', () => {
 			Promise.reject( new Error( 'load failed' ) );
 
 		loadVeMediaInsert( window );
-		env.mw.hook( 've.activationComplete' ).fire();
 		await flush();
 
 		// No throw / unhandled rejection; prototype stays unpatched.

--- a/tests/jest/ve-media-insert.test.js
+++ b/tests/jest/ve-media-insert.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for resources/ve-media-insert.js — the patch that strips the spoofed
+ * `.jpg` from IIIF files when VisualEditor's media dialog turns a chosen
+ * search result into the inserted node (ve.ui.MWMediaDialog#confirmSelectedImage).
+ */
+
+'use strict';
+
+const { createMwEnv, loadVeMediaInsert } = require( './mw-mock' );
+
+// Build a fake ve.ui.MWMediaDialog whose confirmSelectedImage records the
+// title/canonicaltitle visible to it at call time (that's what the real method
+// bakes into the inserted node's resource/href).
+function installFakeVe( win ) {
+	const seen = [];
+	function MWMediaDialog() {}
+	MWMediaDialog.static = { name: 'media' };
+	MWMediaDialog.prototype.confirmSelectedImage = function () {
+		const info = this.selectedImageInfo;
+		seen.push( {
+			title: info && info.title,
+			canonicaltitle: info && info.canonicaltitle,
+		} );
+		return 'inserted';
+	};
+	win.ve = { ui: { MWMediaDialog } };
+	return { MWMediaDialog, seen };
+}
+
+// Flush the microtask queue so mw.loader.using().then( patch ) runs.
+function flush() {
+	return new Promise( ( r ) => setTimeout( r, 0 ) );
+}
+
+let env;
+
+beforeEach( () => {
+	env = createMwEnv( window );
+} );
+
+afterEach( () => {
+	delete window.ve;
+} );
+
+describe( 've-media-insert.js — confirmSelectedImage patch', () => {
+	test( 'un-spoofs title + canonicaltitle for IIIF results, then restores them', async () => {
+		const { MWMediaDialog, seen } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		const dialog = new MWMediaDialog();
+		const info = {
+			isInstantIIIF: true,
+			title: 'File:Df_dk_0007450.jpg',
+			canonicaltitle: 'File:Df_dk_0007450.jpg',
+		};
+		dialog.selectedImageInfo = info;
+
+		const ret = dialog.confirmSelectedImage();
+
+		// The original ran with the un-spoofed title (what gets baked into
+		// the inserted node) …
+		expect( seen ).toHaveLength( 1 );
+		expect( seen[ 0 ].title ).toBe( 'File:Df_dk_0007450' );
+		expect( seen[ 0 ].canonicaltitle ).toBe( 'File:Df_dk_0007450' );
+		// … the original return value is preserved …
+		expect( ret ).toBe( 'inserted' );
+		// … and the cached search-result object is restored to the spoofed
+		// title VE needs to keep rendering it in the grid.
+		expect( info.title ).toBe( 'File:Df_dk_0007450.jpg' );
+		expect( info.canonicaltitle ).toBe( 'File:Df_dk_0007450.jpg' );
+	} );
+
+	test( 'leaves non-IIIF results untouched', async () => {
+		const { MWMediaDialog, seen } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		const dialog = new MWMediaDialog();
+		dialog.selectedImageInfo = { title: 'File:Real_photo.jpg' };
+
+		dialog.confirmSelectedImage();
+
+		// A Commons/local `.jpg` keeps its extension.
+		expect( seen[ 0 ].title ).toBe( 'File:Real_photo.jpg' );
+	} );
+
+	test( 'tolerates a missing selectedImageInfo', async () => {
+		const { MWMediaDialog, seen } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		const dialog = new MWMediaDialog();
+		dialog.selectedImageInfo = null;
+
+		expect( () => dialog.confirmSelectedImage() ).not.toThrow();
+		expect( seen[ 0 ] ).toEqual( { title: null, canonicaltitle: null } );
+	} );
+
+	test( 'un-spoofs title even when canonicaltitle is absent', async () => {
+		const { MWMediaDialog, seen } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		const dialog = new MWMediaDialog();
+		const info = { isInstantIIIF: true, title: 'File:Bsb11610364.jpg' };
+		dialog.selectedImageInfo = info;
+
+		dialog.confirmSelectedImage();
+
+		expect( seen[ 0 ].title ).toBe( 'File:Bsb11610364' );
+		expect( seen[ 0 ].canonicaltitle ).toBeUndefined();
+		expect( info.title ).toBe( 'File:Bsb11610364.jpg' );
+	} );
+
+	test( 'un-spoofs canonicaltitle even when title is absent', async () => {
+		const { MWMediaDialog, seen } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		const dialog = new MWMediaDialog();
+		const info = {
+			isInstantIIIF: true,
+			canonicaltitle: 'File:Bsb11610364.jpg',
+		};
+		dialog.selectedImageInfo = info;
+
+		dialog.confirmSelectedImage();
+
+		expect( seen[ 0 ].title ).toBeUndefined();
+		expect( seen[ 0 ].canonicaltitle ).toBe( 'File:Bsb11610364' );
+	} );
+
+	test( 'does not re-patch the prototype on a second activation', async () => {
+		const { MWMediaDialog } = installFakeVe( window );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+		const patched = MWMediaDialog.prototype.confirmSelectedImage;
+
+		// Second activation must short-circuit on the _instantIIIFPatched guard.
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		expect( MWMediaDialog.prototype.confirmSelectedImage ).toBe( patched );
+	} );
+
+	test( 'does nothing when ve.ui.MWMediaDialog is unavailable', async () => {
+		// ve present but no ui/dialog (e.g. a stripped editor bundle).
+		window.ve = { ui: {} };
+
+		loadVeMediaInsert( window );
+		expect( () => {
+			env.mw.hook( 've.activationComplete' ).fire();
+		} ).not.toThrow();
+		await flush();
+
+		expect( window.ve.ui.MWMediaDialog ).toBeUndefined();
+	} );
+
+	test( 'does nothing when ve is absent entirely', async () => {
+		// No window.ve at all.
+		loadVeMediaInsert( window );
+		expect( () => {
+			env.mw.hook( 've.activationComplete' ).fire();
+		} ).not.toThrow();
+		await flush();
+
+		expect( window.ve ).toBeUndefined();
+	} );
+
+	test( 'swallows a failed mwimage module load', async () => {
+		installFakeVe( window );
+		// Simulate the editor-image module failing to load.
+		env.mw.loader.using = () =>
+			Promise.reject( new Error( 'load failed' ) );
+
+		loadVeMediaInsert( window );
+		env.mw.hook( 've.activationComplete' ).fire();
+		await flush();
+
+		// No throw / unhandled rejection; prototype stays unpatched.
+		expect(
+			window.ve.ui.MWMediaDialog.prototype._instantIIIFPatched
+		).toBeUndefined();
+	} );
+} );

--- a/tests/phpunit/Integration/RepoTest.php
+++ b/tests/phpunit/Integration/RepoTest.php
@@ -60,16 +60,36 @@ class RepoTest extends MediaWikiIntegrationTestCase
         );
     }
 
-    public function testIdPatternsSkipsSourcesWithoutPattern(): void
+    public function testConstructorRejectsSourceMissingIdPattern(): void
     {
-        $repo = $this->makeRepo([
-            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
-            ['id' => 'noPattern'],
-            ['id' => 'emptyPattern', 'idPattern' => ''],
-            'malformedNonArrayEntry',
-        ]);
+        // idPattern is required so a provider is only fetched for ids that
+        // belong to it; a source without one is a configuration error.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("entry 'noPattern' must define");
 
-        self::assertSame(['/^(df_.+)$/'], $repo->idPatterns());
+        $this->makeRepo([
+            ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+            ['id' => 'noPattern', 'manifestPattern' => 'https://example/$1/manifest.json'],
+        ]);
+    }
+
+    public function testConstructorRejectsEmptyIdPattern(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->makeRepo([
+            ['id' => 'emptyPattern', 'idPattern' => ''],
+        ]);
+    }
+
+    public function testConstructorRejectsNonArraySource(): void
+    {
+        // A non-array entry can't carry an idPattern, so it's rejected and
+        // reported by its index.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('entry #0 must define');
+
+        $this->makeRepo([ 'malformedNonArrayEntry' ]);
     }
 
     public function testGetInfoExposesApiUrlForJs(): void
@@ -139,7 +159,11 @@ class RepoTest extends MediaWikiIntegrationTestCase
     {
         $sources = [
             ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
-            ['id' => 'slub', 'manifestPattern' => 'https://example/$1/manifest.json'],
+            [
+                'id' => 'slub',
+                'idPattern' => '/^([0-9].+)$/',
+                'manifestPattern' => 'https://example/$1/manifest.json',
+            ],
         ];
         $repo = $this->makeRepo($sources);
 
@@ -154,7 +178,11 @@ class RepoTest extends MediaWikiIntegrationTestCase
     public function testNewFileFromTitleObjectReturnsIiifFile(): void
     {
         $repo = $this->makeRepo([
-            ['id' => 'fotothek', 'manifestPattern' => 'https://example/$1/manifest.json'],
+            [
+                'id' => 'fotothek',
+                'idPattern' => '/^(df_.+)$/',
+                'manifestPattern' => 'https://example/$1/manifest.json',
+            ],
         ]);
         $title = Title::makeTitle(NS_FILE, 'Df_dk_0007450');
 
@@ -171,7 +199,11 @@ class RepoTest extends MediaWikiIntegrationTestCase
     public function testNewFileFromStringReturnsIiifFile(): void
     {
         $repo = $this->makeRepo([
-            ['id' => 'fotothek', 'manifestPattern' => 'https://example/$1/manifest.json'],
+            [
+                'id' => 'fotothek',
+                'idPattern' => '/^(df_.+)$/',
+                'manifestPattern' => 'https://example/$1/manifest.json',
+            ],
         ]);
 
         $file = $repo->newFile('File:Df_dk_0007450');

--- a/tests/phpunit/Unit/IIIFFileTest.php
+++ b/tests/phpunit/Unit/IIIFFileTest.php
@@ -869,7 +869,7 @@ class IIIFFileTest extends TestCase
         $title = new Title('Df_dk_0007450', NS_FILE, 'File');
 
         $file = $this->makeFileWithRealResolve(
-            [['id' => 'deutsche-fotothek', 'manifestPattern' => 'https://fotothek.example/$1/manifest.json']],
+            [['id' => 'deutsche-fotothek', 'idPattern' => '/^df_/', 'manifestPattern' => 'https://fotothek.example/$1/manifest.json']],
             ['https://fotothek.example/df_dk_0007450/manifest.json' => $manifest],
             $title,
         );
@@ -1021,6 +1021,7 @@ class IIIFFileTest extends TestCase
                 // Second entry: matches and returns a valid manifest.
                 [
                     'id' => 'deutsche-fotothek',
+                    'idPattern' => '/^df_/',
                     'manifestPattern' => 'https://fotothek.example/$1/manifest.json',
                 ],
             ],
@@ -1115,7 +1116,10 @@ class IIIFFileTest extends TestCase
         $title = new Title('Df_dk_0007450', NS_FILE, 'File');
         $file = $this->makeFileWithRealResolve(
             [
-                ['id' => 'no-pattern'],
+                // idPattern matches, but there's no manifestPattern to build
+                // a URL from — the manifestPattern guard returns before any
+                // fetch.
+                ['id' => 'no-manifest', 'idPattern' => '/^df_/'],
             ],
             [],
             $title,
@@ -1133,6 +1137,7 @@ class IIIFFileTest extends TestCase
             [
                 [
                     'id' => 'fetches-but-fails',
+                    'idPattern' => '/^df_/',
                     'manifestPattern' => 'https://fotothek.example/$1/manifest.json',
                 ],
             ],
@@ -1154,6 +1159,7 @@ class IIIFFileTest extends TestCase
             [
                 [
                     'id' => 'fotothek',
+                    'idPattern' => '/^df_/',
                     'manifestPattern' => 'https://fotothek.example/$1/manifest.json',
                 ],
             ],
@@ -1171,7 +1177,7 @@ class IIIFFileTest extends TestCase
         $file = $this->makeFileWithRealResolve(
             [
                 // No `id` key → default to 'default'.
-                ['manifestPattern' => 'https://fotothek.example/$1/manifest.json'],
+                ['idPattern' => '/^df_/', 'manifestPattern' => 'https://fotothek.example/$1/manifest.json'],
             ],
             ['https://fotothek.example/df_dk_0007450/manifest.json' => $manifest],
             $title,

--- a/tests/playwright/e2e/imageinfo-api.spec.js
+++ b/tests/playwright/e2e/imageinfo-api.spec.js
@@ -45,7 +45,7 @@ test.describe( 'imageinfo API — IIIF upload timestamp', () => {
 		const page = await imageInfo( request, 'File:Df_dk_0007450.jpg' );
 
 		// Sanity: the file resolves through the IIIF repo.
-		expect( page.imagerepository ).toBe( 'iiif-test' );
+		expect( page.imagerepository ).toBe( 'iiif' );
 
 		const info = page.imageinfo[ 0 ];
 		// The misleading "uploaded just now" timestamp must not be emitted.
@@ -59,7 +59,7 @@ test.describe( 'imageinfo API — IIIF upload timestamp', () => {
 	} ) => {
 		const page = await imageInfo( request, 'File:Df_dk_multipage.jpg' );
 
-		expect( page.imagerepository ).toBe( 'iiif-test' );
+		expect( page.imagerepository ).toBe( 'iiif' );
 
 		const info = page.imageinfo[ 0 ];
 		expect( info.timestamp ).toBeFalsy();

--- a/tests/playwright/e2e/ve-media-insert.spec.js
+++ b/tests/playwright/e2e/ve-media-insert.spec.js
@@ -1,0 +1,124 @@
+// @ts-check
+/* global ve */
+const test = require( './fixtures' );
+const { expect } = require( '@playwright/test' );
+
+/**
+ * VisualEditor "Insert media" dialog must insert IIIF files WITHOUT the
+ * spoofed `.jpg` extension, so VE-inserted embeds match hand-written
+ * `[[File:<id>]]` wikitext.
+ *
+ * The dialog still needs the spoofed title to *display* the search result
+ * (VE filters media results by file extension — see media-search.js), so the
+ * fix strips `.jpg` only when the chosen result is turned into the inserted
+ * node (ve.ui.MWMediaDialog#confirmSelectedImage). This drives the real
+ * search → choose → confirm → insert → serialize path and asserts the
+ * serialized wikitext carries no `.jpg`.
+ */
+test( 'VE media dialog inserts IIIF files without the spoofed .jpg', async ( {
+	page,
+} ) => {
+	// Defaults to the Docker test page; overridable so the same spec can run
+	// against another wiki (e.g. the staging server's Kornhaus article).
+	const editPage = process.env.VE_TEST_PAGE || 'Mei%C3%9Fen%20Rathaus';
+	await page.goto( '/wiki/' + editPage + '?veaction=edit' );
+
+	await page.waitForFunction(
+		() =>
+			window.ve &&
+			ve.init &&
+			ve.init.target &&
+			ve.init.target.getSurface &&
+			ve.init.target.getSurface() &&
+			ve.ui.MWMediaDialog,
+		{ timeout: 25_000 }
+	);
+
+	const outcome = await page.evaluate( async ( searchId ) => {
+		const surface = ve.init.target.getSurface();
+		const surfaceModel = surface.getModel();
+
+		// Dismiss any dialog already open — e.g. VE's beta-welcome dialog,
+		// which a freshly-configured wiki shows on first edit and which would
+		// otherwise sit in front of the media dialog. Harmless when none is
+		// open (getCurrentWindow() is null).
+		await new Promise( ( r ) => setTimeout( r, 500 ) );
+		const dialogs = surface.getDialogs();
+		const existing = dialogs.getCurrentWindow();
+		if ( existing && existing.constructor.static.name !== 'media' ) {
+			await dialogs.closeWindow( existing ).closed;
+		}
+
+		// Open the real media dialog the way the toolbar command does.
+		surface.execute( 'window', 'open', 'media', {
+			surface: surfaceModel,
+			fragment: surfaceModel.getFragment(),
+		} );
+		const dialog = await new Promise( ( resolve, reject ) => {
+			const deadline = Date.now() + 10_000;
+			( function poll() {
+				const d = surface.getDialogs().getCurrentWindow();
+				if ( d && d.constructor.static.name === 'media' ) {
+					resolve( d );
+				} else if ( Date.now() > deadline ) {
+					reject( new Error( 'media dialog did not open' ) );
+				} else {
+					setTimeout( poll, 150 );
+				}
+			} )();
+		} );
+
+		// Drive the dialog's own search (exercises media-search.js).
+		dialog.search.getQuery().setValue( searchId );
+		dialog.search.queryMediaQueue();
+
+		// Wait for a result tile to appear.
+		const items = await new Promise( ( resolve, reject ) => {
+			const deadline = Date.now() + 15_000;
+			( function poll() {
+				const got = dialog.search.getResults().getItems();
+				if ( got.length ) {
+					resolve( got );
+				} else if ( Date.now() > deadline ) {
+					reject( new Error( 'no media results' ) );
+				} else {
+					setTimeout( poll, 200 );
+				}
+			} )();
+		} );
+
+		const data = items[ 0 ].getData();
+		// Captured before confirm: this is the title VE actually displayed in
+		// the results grid (must stay spoofed for VE to show it at all).
+		const displayedTitle = data.title;
+
+		// Choose → confirm → insert exactly as the dialog's UI would.
+		dialog.chooseImageInfo( data );
+		dialog.confirmSelectedImage();
+		dialog.imageModel.insertImageNode( dialog.getFragment() );
+
+		const wikitext = await ve.init.target.getWikitextFragment(
+			surfaceModel.getDocument(),
+			false
+		);
+
+		return {
+			resultTitle: displayedTitle, // what VE displayed (stays spoofed)
+			restoredTitle: data.title, // patch must restore the spoofed title
+			resourceName: dialog.imageModel.getResourceName(), // inserted target
+			wikitext,
+		};
+	}, 'df_dk_0007450' );
+
+	// The search result VE displayed kept its spoofed `.jpg` (required for VE
+	// to show it at all) — confirms we exercised the real, working search.
+	expect( outcome.resultTitle ).toMatch( /\.jpg$/i );
+	// And the patch restored that spoofed title afterwards, leaving VE's
+	// cached search-result object untouched for re-rendering the grid.
+	expect( outcome.restoredTitle ).toMatch( /\.jpg$/i );
+
+	// The inserted resource and the serialized wikitext must be extension-less.
+	expect( outcome.resourceName ).not.toMatch( /\.jpg$/i );
+	expect( outcome.wikitext ).toMatch( /\[\[File:Df[ _]dk[ _]0007450/i );
+	expect( outcome.wikitext ).not.toMatch( /Df[ _]dk[ _]0007450\.jpg/i );
+} );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



**What is the current behavior?** (You can also link to an open issue here)
When adding IIIF images via the Visual Editor search dialog, the spoofed `.jpg` extension is added to the article, e.g., `[[File:abc.jpg]]`. This differs from manually typed `[[File:…]]` calls where the spoofed extension is omitted.


**What is the new behavior (if this is a feature change)?**
IIIF images added via the VisualEditor no longer add the spoofed extension to the article, e.g., `[[File:abc]]`


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. The extensions require` the `idPattern` config property now and do` nothing if it's missing.


**Other information**:
Making `idPattern` required arose from trying to use it to flag when an IIIF search is performed, making it a required config. Ultimately, the approach was changed, but requiring it is good practice to prevent unnecessary HTTP calls to IIIF providers, so it was kept.