### PR TITLE
Add local image cache

### DIFF
--- a/.docker/LocalSettings.php
+++ b/.docker/LocalSettings.php
@@ -66,6 +66,13 @@ $wgForeignFileRepos[] = [
     'class' => \MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo::class,
     'directory' => '/tmp/iiif-repo',
     'hashLevels' => 0,
+    # Local image caching defaults ON. It is disabled here so the e2e suite
+    # keeps asserting the provider-hotlink URLs (enabling it rewrites thumbnail
+    # and full-image URLs to local /images/iiif-cache/ copies). To exercise the
+    # cached path, set this to e.g. 31536000 and ensure the thumb zone is both
+    # writable and web-served (point `directory` at $wgUploadDirectory, or add a
+    # server alias for the cache URL).
+    'imageCacheExpiry' => 0,
     'iiifSources' => [
         [
             'id' => 'deutsche-fotothek',

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
   e2e-playwright:
     uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@main
     with:
-      NODE_VERSION: '18'
+      NODE_VERSION: '22'
       PLAYWRIGHT_SCRIPT: 'test:e2e'
       PLAYWRIGHT_ARTIFACT_PATH: 'test-results/'
       PLAYWRIGHT_ARTIFACT_RETENTION_DAYS: 7

--- a/.github/workflows/quality-assurance-assets.yml
+++ b/.github/workflows/quality-assurance-assets.yml
@@ -9,4 +9,9 @@ jobs:
   wp-scripts-lint:
     uses: inpsyde/reusable-workflows/.github/workflows/wp-scripts-lint.yml@main
     with:
+      # The reusable workflow defaults to Node 18. @wordpress/eslint-plugin
+      # eagerly loads every rule, and no-unknown-ds-tokens.js require()s an
+      # ESM-only module — which needs a Node with require(ESM) support
+      # (>= 20.19 / >= 22.12). On 18 it dies with ERR_REQUIRE_ESM.
+      NODE_VERSION: '22'
       LINT_TOOLS: '["js", "md-docs"]'

--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -31,9 +31,23 @@ class FileRepo {
     public function getInfo(): array {}
 
     public function getBackend(): \FileBackend {}
+
+    public function getZonePath(string $zone): ?string {}
+
+    /** @param string|null $ext @return string|false */
+    public function getZoneUrl(string $zone, $ext = null) {}
+
+    public function getHashPath(string $name): string {}
 }
 
-class FileBackend {}
+class FileBackend {
+    /** @param array<string, mixed> $params */
+    public function fileExists(array $params): bool {}
+    /** @param array<string, mixed> $params */
+    public function prepare(array $params): StatusValue {}
+    /** @param array<string, mixed> $params */
+    public function quickCreate(array $params): StatusValue {}
+}
 
 class MediaTransformOutput {
 }

--- a/.phpstan/stubs/MediaWikiNamespaced.stub.php
+++ b/.phpstan/stubs/MediaWikiNamespaced.stub.php
@@ -18,9 +18,11 @@ class Title {
 namespace MediaWiki;
 
 use GlobalVarConfig;
+use MediaWiki\FileBackend\LockManager\LockManagerGroupFactory;
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\Utils\UrlUtils;
 use WANObjectCache;
+use Wikimedia\FileBackend\FSFile\TempFSFileFactory;
 
 class MediaWikiServices {
     public static function getInstance(): self {}
@@ -30,12 +32,16 @@ class MediaWikiServices {
     public function getRepoGroup(): \RepoGroup {}
     public function getContentLanguage(): \Language {}
     public function getUrlUtils(): UrlUtils {}
+    public function getLockManagerGroupFactory(): LockManagerGroupFactory {}
+    public function getTempFSFileFactory(): TempFSFileFactory {}
 }
 
 class MainConfigNames {
     public const ScriptPath = 'ScriptPath';
     public const Script = 'Script';
     public const UploadDirectory = 'UploadDirectory';
+    public const UploadPath = 'UploadPath';
+    public const DirectoryMode = 'DirectoryMode';
 }
 
 namespace MediaWiki\Utils;
@@ -128,4 +134,46 @@ interface ImagePageFileHistoryLineHook {
 
 interface ImagePageShowTOCHook {
     public function onImagePageShowTOC($page, &$toc);
+}
+
+namespace MediaWiki\Status;
+
+class Status extends \StatusValue {
+    public static function wrap(\StatusValue $sv): self {}
+}
+
+namespace MediaWiki\Logger;
+
+use Psr\Log\LoggerInterface;
+
+class LoggerFactory {
+    public static function getInstance(string $channel): LoggerInterface {}
+}
+
+namespace MediaWiki\WikiMap;
+
+class WikiMap {
+    public static function getCurrentWikiId(): string {}
+}
+
+namespace MediaWiki\FileBackend\LockManager;
+
+class LockManagerGroupFactory {
+    public function getLockManagerGroup(string|false $domain = false): LockManagerGroup {}
+}
+
+class LockManagerGroup {
+    public function get(string $name): object {}
+}
+
+namespace Wikimedia\FileBackend\FSFile;
+
+class TempFSFileFactory {
+}
+
+namespace Wikimedia\FileBackend;
+
+class FSFileBackend extends \FileBackend {
+    /** @param array<string, mixed> $config */
+    public function __construct(array $config) {}
 }

--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ Once the extension is loaded, IIIF identifiers also resolve in VisualEditor's "I
 
 `$wgForeignFileRepos[]` entry — top level:
 
-| Key           | Required | Description                                                    |
-|---------------|----------|----------------------------------------------------------------|
-| `name`        | yes      | The MediaWiki repo name. Conventionally `iiif`.                |
-| `class`       | yes      | Must be `\MediaWiki\Extension\InstantIIIF\Repo::class`.        |
-| `hashLevels`  | yes      | `0` — IIIF has no local storage, but FileRepo needs the field. |
-| `iiifSources` | yes      | List of provider entries (see below).                          |
+| Key                | Required | Description                                                                                                                                                                  |
+|--------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`             | yes      | The MediaWiki repo name. Conventionally `iiif`.                                                                                                                              |
+| `class`            | yes      | Must be `\MediaWiki\Extension\InstantIIIF\Repo::class`.                                                                                                                      |
+| `hashLevels`       | yes      | `0` — IIIF has no local storage, but FileRepo needs the field.                                                                                                               |
+| `iiifSources`      | yes      | List of provider entries (see below).                                                                                                                                        |
+| `imageCacheExpiry` | no       | Local image-cache TTL in seconds; `0` disables caching. Defaults to `31536000` (one year), so caching is **on by default**. See [Local image caching](#local-image-caching). |
 
 Each entry in `iiifSources`:
 
@@ -136,9 +137,33 @@ Each entry in `iiifSources`:
 
 Optional globals:
 
-| Variable                       | Default | Description                                                          |
-|--------------------------------|---------|----------------------------------------------------------------------|
-| `$wgInstantIIIFDefaultTimeout` | `5`     | HTTP timeout in seconds for fetching IIIF manifests and `info.json`. |
+| Variable                       | Default | Description                                                                                       |
+|--------------------------------|---------|---------------------------------------------------------------------------------------------------|
+| `$wgInstantIIIFDefaultTimeout` | `5`     | HTTP timeout in seconds for fetching IIIF manifests, `info.json`, and (when caching) image bytes. |
+
+### Local image caching
+
+By default InstantIIIF caches image bytes locally so each distinct `(image, size)` is fetched from the provider **at most once**, then served from the wiki afterwards. This applies to inline thumbnails, the full-resolution image (MultimediaViewer, the "Original file" link, the imageinfo `url` field), and — via a shared TTL — the manifest / `info.json` WAN cache. Caching is write-once: a stored copy is never revalidated against the provider, since IIIF object bytes are immutable. The net effect is to keep outbound traffic to the source institution to a minimum.
+
+Cached bytes are stored in a dedicated `thumb` zone, by default in the `iiif-cache` container under `$wgUploadDirectory` (served from `$wgUploadPath/iiif-cache`). The repo's `directory` is left untouched. The cache directory must be **writable by the web server** and the URL must be **web-served**.
+
+```php
+$wgForeignFileRepos[] = [
+    // …name, class, iiifSources…
+    'imageCacheExpiry' => 31536000, // 1 year (default). Set to 0 to disable.
+];
+```
+
+To relocate the cache (e.g. onto a separate volume), configure the `thumb` zone the native FileRepo way — an explicit `zones.thumb` is respected and not overridden:
+
+```php
+    'zones' => [ 'thumb' => [
+        'container' => 'iiif-cache',
+        'url'       => '/iiif-cache',   // must map to the served directory
+    ] ],
+```
+
+There is currently no automatic eviction — cached files accumulate until removed manually (e.g. by pruning the cache directory by modification time).
 
 ## Diagnostics: Special:InstantIIIFInspect
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -14,6 +14,7 @@ module.exports = [
 			'**/build/**',
 			'**/node_modules/**',
 			'**/vendor/**',
+			'**/coverage/**',
 			'**/playwright-report/**',
 			'**/test-results/**',
 		],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "jest-mock": "^30.4.1"
     },
     "engines": {
-        "node": "~18.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
     },
     "jest": {
         "testEnvironment": "jsdom",

--- a/src/Infrastructure/CachedHttpManifestFetcher.php
+++ b/src/Infrastructure/CachedHttpManifestFetcher.php
@@ -19,13 +19,23 @@ use WANObjectCache;
  */
 final class CachedHttpManifestFetcher implements ManifestFetcher
 {
-    private const CACHE_TTL_SECONDS = 3600;
+    /**
+     * Fallback TTL used when the caller does not pass one (e.g. when image
+     * caching is disabled, so the repo has no configured expiry). Manifests
+     * and info.json change rarely, but this keeps a conservative refresh.
+     */
+    public const DEFAULT_TTL_SECONDS = 3600;
+
+    private int $ttl;
 
     public function __construct(
         private WANObjectCache $cache,
         private HttpRequestFactory $httpFactory,
-        private Config $config
+        private Config $config,
+        ?int $ttl = null
     ) {
+
+        $this->ttl = $ttl !== null && $ttl > 0 ? $ttl : self::DEFAULT_TTL_SECONDS;
     }
 
     public function fetch(string $url): ?array
@@ -34,11 +44,11 @@ final class CachedHttpManifestFetcher implements ManifestFetcher
 
         $value = $this->cache->getWithSetCallback(
             $key,
-            self::CACHE_TTL_SECONDS,
+            $this->ttl,
             function () use ($url): ?array {
                 return $this->fetchAndDecode($url);
             },
-            ['pcTTL' => self::CACHE_TTL_SECONDS]
+            ['pcTTL' => $this->ttl]
         );
 
         return is_array($value) ? $value : null;

--- a/src/Infrastructure/MediaWiki/IIIFFile.php
+++ b/src/Infrastructure/MediaWiki/IIIFFile.php
@@ -195,7 +195,10 @@ class IIIFFile extends File
     public function getUrl(): string
     {
         $serviceId = $this->serviceIdForPage($this->resolveCurrentPage());
-        return $serviceId !== null ? ImageService::fullUrlFor($serviceId) : '';
+        if ($serviceId === null) {
+            return '';
+        }
+        return $this->cachedImageUrl(ImageService::fullUrlFor($serviceId));
     }
 
     /**
@@ -222,7 +225,10 @@ class IIIFFile extends File
     public function getUrlForPage(int $page): string
     {
         $serviceId = $this->serviceIdForPage(Page::normalize($page));
-        return $serviceId !== null ? ImageService::fullUrlFor($serviceId) : '';
+        if ($serviceId === null) {
+            return '';
+        }
+        return $this->cachedImageUrl(ImageService::fullUrlFor($serviceId));
     }
 
     /**
@@ -416,7 +422,7 @@ class IIIFFile extends File
     ): ThumbnailImage {
 
         if (!$width && !$height) {
-            return new ThumbnailImage($this, $service->fullUrl(), false, [
+            return new ThumbnailImage($this, $this->cachedImageUrl($service->fullUrl()), false, [
                 'width' => $original->width,
                 'height' => $original->height,
                 'page' => $page->value,
@@ -434,11 +440,47 @@ class IIIFFile extends File
             $clampedW = $clampedW ?: (int) round($original->width * ($clampedH / $original->height));
         }
 
-        return new ThumbnailImage($this, $service->sizedUrl($width, $height), false, [
+        $url = $this->cachedImageUrl($service->sizedUrl($width, $height));
+        return new ThumbnailImage($this, $url, false, [
             'width' => $clampedW,
             'height' => $clampedH,
             'page' => $page->value,
         ]);
+    }
+
+    /* -------------------- Local image cache -------------------- */
+
+    /**
+     * Route a remote IIIF Image API URL through the local cache, returning a
+     * local wiki URL when the bytes are cached (or could be fetched + stored)
+     * and falling back to the remote URL otherwise. Applied to both thumbnail
+     * transforms and the full-resolution URL methods so that — once warmed —
+     * neither the inline thumbnails nor MMV's full-size image nor the
+     * imageinfo `url` field send traffic to the provider.
+     */
+    private function cachedImageUrl(string $remoteUrl): string
+    {
+        return $this->imageCache()?->localUrlFor($remoteUrl) ?? $remoteUrl;
+    }
+
+    /**
+     * Build the image cache for this file's repo, or null when the repo is
+     * not an InstantIIIF Repo or has caching disabled. Protected so tests can
+     * override it without a real FileBackend (mirrors manifestFetcher()).
+     */
+    protected function imageCache(): ?ImageCache
+    {
+        $repo = $this->repo;
+        if (!$repo instanceof Repo || !$repo->cacheImagesEnabled()) {
+            return null;
+        }
+        $services = MediaWikiServices::getInstance();
+        return new IIIFImageCache(
+            $repo,
+            $services->getHttpRequestFactory(),
+            $repo->imageCacheExpiry(),
+            (int) $services->getMainConfig()->get('InstantIIIFDefaultTimeout')
+        );
     }
 
     /* -------------------- Resolution helpers -------------------- */
@@ -621,7 +663,7 @@ class IIIFFile extends File
      */
     protected function fetchJsonCached(string $url): ?array
     {
-        return self::manifestFetcher()->fetch($url);
+        return $this->manifestFetcher()->fetch($url);
     }
 
     /**
@@ -638,14 +680,30 @@ class IIIFFile extends File
         return $info;
     }
 
-    private static function manifestFetcher(): ManifestFetcher
+    private function manifestFetcher(): ManifestFetcher
     {
         $services = MediaWikiServices::getInstance();
         return new CachedHttpManifestFetcher(
             $services->getMainWANObjectCache(),
             $services->getHttpRequestFactory(),
-            $services->getMainConfig()
+            $services->getMainConfig(),
+            $this->manifestCacheTtl()
         );
+    }
+
+    /**
+     * TTL for the manifest/info.json WAN cache. Reuses the repo's image-cache
+     * expiry so a single `imageCacheExpiry` setting governs all IIIF caching;
+     * falls back to the fetcher default when caching is off or the repo is
+     * not an InstantIIIF Repo.
+     */
+    private function manifestCacheTtl(): int
+    {
+        $repo = $this->repo;
+        if ($repo instanceof Repo && $repo->imageCacheExpiry() > 0) {
+            return $repo->imageCacheExpiry();
+        }
+        return CachedHttpManifestFetcher::DEFAULT_TTL_SECONDS;
     }
 
     /**

--- a/src/Infrastructure/MediaWiki/IIIFImageCache.php
+++ b/src/Infrastructure/MediaWiki/IIIFImageCache.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki;
+
+use MediaWiki\Http\HttpRequestFactory;
+
+/**
+ * Stores remote IIIF image bytes in the repo's `thumb` zone on first use and
+ * serves every later request from the local copy, so each distinct
+ * (image, size) URL is fetched from the provider at most once.
+ *
+ * Reuses the storage primitives the repo already inherits from FileRepo
+ * (`getBackend()`, `getZonePath()`, `getZoneUrl()`, `getHashPath()`) rather
+ * than MediaWiki's ForeignAPIRepo caching, which is welded to the MediaWiki
+ * API path InstantIIIF doesn't use.
+ *
+ * Deliberately write-once: unlike ForeignAPIRepo's cache it never revalidates
+ * against the provider on a hit. IIIF object bytes are immutable, and the
+ * point of caching here is to minimise outbound requests to the provider —
+ * revalidation would defeat that.
+ *
+ * The local path/URL is derived from sha1 of the *full* remote URL (not its
+ * basename — every IIIF URL ends in `default.jpg`, which would collide across
+ * every page, region and size).
+ */
+final class IIIFImageCache implements ImageCache
+{
+    /** Spoofed extension so the stored object looks like the JPEG it is. */
+    private const FILE_EXTENSION = '.jpg';
+
+    public function __construct(
+        private Repo $repo,
+        private HttpRequestFactory $httpFactory,
+        private int $expiry,
+        private int $timeout
+    ) {
+    }
+
+    public function localUrlFor(string $remoteUrl): ?string
+    {
+        if ($this->expiry <= 0) {
+            return null;
+        }
+
+        $zonePath = $this->repo->getZonePath('thumb');
+        $zoneUrl = $this->repo->getZoneUrl('thumb');
+        if (!is_string($zonePath) || $zonePath === '' || !is_string($zoneUrl) || $zoneUrl === '') {
+            // No writable/served cache zone configured — fall back to remote.
+            return null;
+        }
+
+        $name = sha1($remoteUrl) . self::FILE_EXTENSION;
+        $relPath = $this->repo->getHashPath($name) . $name;
+        $localFile = rtrim($zonePath, '/') . '/' . $relPath;
+        $localUrl = rtrim($zoneUrl, '/') . '/' . $relPath;
+
+        $backend = $this->repo->getBackend();
+        if ($backend->fileExists(['src' => $localFile])) {
+            // Hit: serve the stored copy, zero provider traffic.
+            return $localUrl;
+        }
+
+        $bytes = $this->fetch($remoteUrl);
+        if ($bytes === null) {
+            return null;
+        }
+
+        $backend->prepare(['dir' => dirname($localFile)]);
+        if (!$backend->quickCreate(['dst' => $localFile, 'content' => $bytes])->isOK()) {
+            return null;
+        }
+
+        return $localUrl;
+    }
+
+    /**
+     * Download the image bytes, or null on transport failure / empty body.
+     */
+    private function fetch(string $url): ?string
+    {
+        $req = $this->httpFactory->create($url, ['timeout' => $this->timeout], __METHOD__);
+        if (!$req->execute()->isOK()) {
+            return null;
+        }
+        $body = $req->getContent();
+        return $body === '' ? null : $body;
+    }
+}

--- a/src/Infrastructure/MediaWiki/ImageCache.php
+++ b/src/Infrastructure/MediaWiki/ImageCache.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki;
+
+/**
+ * Port for a local cache of remote IIIF image bytes.
+ *
+ * Implementations take a remote IIIF Image API URL and return a local wiki
+ * URL serving a cached copy of those bytes, fetching and storing them on
+ * first use. Returning null signals "not cached / caching unavailable", so
+ * callers fall back to hotlinking the remote URL — the cache is always an
+ * optimisation, never a hard dependency.
+ */
+interface ImageCache
+{
+    /**
+     * Local URL for a cached copy of $remoteUrl, or null when caching is
+     * disabled or any step (fetch/store) fails.
+     */
+    public function localUrlFor(string $remoteUrl): ?string;
+}

--- a/src/Infrastructure/MediaWiki/Repo.php
+++ b/src/Infrastructure/MediaWiki/Repo.php
@@ -4,15 +4,37 @@ declare(strict_types=1);
 
 namespace MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki;
 
+use FileBackend;
 use FileRepo;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Status\Status;
 use MediaWiki\Title\Title;
+use MediaWiki\WikiMap\WikiMap;
+use Wikimedia\FileBackend\FSFileBackend;
 
 class Repo extends FileRepo
 {
+    /**
+     * Default image-cache TTL: one year. IIIF object bytes (and their
+     * manifests) are effectively immutable, so caching is enabled by
+     * default; set `imageCacheExpiry => 0` in the repo config to disable.
+     */
+    public const DEFAULT_IMAGE_CACHE_EXPIRY = 31536000;
+
+    /**
+     * Container — and default URL leaf under $wgUploadPath — for cached IIIF
+     * image bytes. Kept in a dedicated zone so the cache is isolated from
+     * genuine local uploads (safe to prune wholesale, excludable from
+     * backups, clearly an ephemeral hot-cache rather than a republication).
+     */
+    private const CACHE_CONTAINER = 'iiif-cache';
+
     /** @var array<int, array<string, mixed>> */
     private array $iiifSources = [];
+
+    private int $imageCacheExpiry = 0;
 
     /**
      * @param array<string, mixed> $info
@@ -20,18 +42,169 @@ class Repo extends FileRepo
     public function __construct(array $info)
     {
         // FileBackendGroup requires 'directory' for auto-backend creation;
-        // IIIF has no local storage, so we default to the upload dir.
-        // Core constructs the repo from the $info array, so there is no
-        // constructor DI here — read the upload dir from the Config service.
+        // it is the FS root of the repo's backend. Core constructs the repo
+        // from the $info array, so there is no constructor DI here — read the
+        // upload dir from the Config service.
         if (!isset($info['directory'])) {
             $info['directory'] = (string) MediaWikiServices::getInstance()
                 ->getMainConfig()
                 ->get(MainConfigNames::UploadDirectory);
         }
+
+        $expiry = (int) ($info['imageCacheExpiry'] ?? self::DEFAULT_IMAGE_CACHE_EXPIRY);
+        if ($expiry > 0) {
+            $info = self::withCacheZone($info);
+            $info = self::withCacheBackend($info);
+        }
+
         parent::__construct($info);
+
+        $this->imageCacheExpiry = $expiry;
         $sources = $info['iiifSources'] ?? [];
         self::assertSourcesHaveIdPattern($sources);
         $this->iiifSources = $sources;
+    }
+
+    /**
+     * Configure the `thumb` zone used to store cached IIIF image bytes.
+     *
+     * Leaves the repo's `directory` (the auto-backend root) untouched and
+     * isolates the cache in its own container served from a dedicated URL,
+     * defaulting to `{$wgUploadPath}/iiif-cache`. Supplying the URL is the
+     * one genuinely new piece of config: FileRepo gives every repo a `thumb`
+     * zone by default but with no `url`, so it cannot be served otherwise.
+     * An explicitly configured `zones.thumb` is respected and never
+     * overridden, so admins can relocate the cache the native FileRepo way.
+     *
+     * @param array<string, mixed> $info
+     * @return array<string, mixed>
+     */
+    private static function withCacheZone(array $info): array
+    {
+        $zones = $info['zones'] ?? [];
+        if (!is_array($zones)) {
+            $zones = [];
+        }
+        if (isset($zones['thumb'])) {
+            return $info;
+        }
+        $uploadPath = (string) MediaWikiServices::getInstance()
+            ->getMainConfig()
+            ->get(MainConfigNames::UploadPath);
+        $zones['thumb'] = [
+            'container' => self::CACHE_CONTAINER,
+            'url' => rtrim($uploadPath, '/') . '/' . self::CACHE_CONTAINER,
+        ];
+        $info['zones'] = $zones;
+        return $info;
+    }
+
+    /**
+     * Give the repo a backend that can actually resolve the cache container.
+     *
+     * `FileBackendGroup` builds a repo's auto-backend straight from the raw
+     * `$wgForeignFileRepos` config — it never instantiates this class, so the
+     * `iiif-cache` container added by withCacheZone() is unknown to it, and
+     * for a plain FileRepo subclass (unlike ForeignAPIRepo) it never defaults
+     * `directory` either, leaving the default-zone containers on relative
+     * paths with a null basePath. Either way every cache write fails with
+     * `backend-fail-invalidpath` / `directorycreateerror` and
+     * IIIFImageCache silently falls back to hotlinking.
+     *
+     * So when we manage the default cache zone and no backend object was
+     * injected, build an FSFileBackend ourselves with absolute container
+     * paths — including `iiif-cache` — mirroring how core wires LocalRepo /
+     * ForeignAPIRepo backends. An explicitly supplied backend (tests,
+     * FileBackendMultiWrite, admin config) is left untouched.
+     *
+     * @param array<string, mixed> $info
+     * @return array<string, mixed>
+     */
+    private static function withCacheBackend(array $info): array
+    {
+        if (($info['backend'] ?? null) instanceof FileBackend) {
+            return $info;
+        }
+        if (!self::usesDefaultCacheZone($info)) {
+            return $info;
+        }
+        $info['backend'] = self::buildCacheBackend($info);
+        return $info;
+    }
+
+    /**
+     * Whether the `thumb` zone routes to our dedicated cache container — i.e.
+     * withCacheZone() supplied it rather than the admin relocating the cache
+     * to a container they are responsible for backing themselves.
+     *
+     * @param array<string, mixed> $info
+     */
+    private static function usesDefaultCacheZone(array $info): bool
+    {
+        $zones = $info['zones'] ?? [];
+        return is_array($zones)
+            && is_array($zones['thumb'] ?? null)
+            && ($zones['thumb']['container'] ?? null) === self::CACHE_CONTAINER;
+    }
+
+    /**
+     * Construct an FSFileBackend with absolute container paths rooted at the
+     * repo's `directory`, including the dedicated `iiif-cache` container. The
+     * service-level wiring (lock manager, temp-file factory, WAN cache,
+     * status wrapper, logger) mirrors what FileBackendGroup injects into an
+     * auto-created backend so the cache behaves like any other FS backend.
+     *
+     * @param array<string, mixed> $info
+     */
+    private static function buildCacheBackend(array $info): FileBackend
+    {
+        $services = MediaWikiServices::getInstance();
+
+        $name = (string) ($info['name'] ?? 'iiif');
+        $backendName = is_string($info['backend'] ?? null) && $info['backend'] !== ''
+            ? (string) $info['backend']
+            : $name . '-backend';
+        $directory = rtrim((string) $info['directory'], '/');
+
+        return new FSFileBackend([
+            'name' => $backendName,
+            'domainId' => WikiMap::getCurrentWikiId(),
+            'basePath' => $directory,
+            'containerPaths' => [
+                "{$name}-public" => $directory,
+                "{$name}-thumb" => $info['thumbDir'] ?? "{$directory}/thumb",
+                "{$name}-transcoded" => $info['transcodedDir'] ?? "{$directory}/transcoded",
+                "{$name}-deleted" => $info['deletedDir'] ?? false,
+                "{$name}-temp" => "{$directory}/temp",
+                self::CACHE_CONTAINER => "{$directory}/" . self::CACHE_CONTAINER,
+            ],
+            'fileMode' => $info['fileMode'] ?? 0644,
+            'directoryMode' => $services->getMainConfig()->get(MainConfigNames::DirectoryMode),
+            'lockManager' => $services->getLockManagerGroupFactory()
+                ->getLockManagerGroup()
+                ->get((string) ($info['lockManager'] ?? 'fsLockManager')),
+            'tmpFileFactory' => $services->getTempFSFileFactory(),
+            'wanCache' => $services->getMainWANObjectCache(),
+            'statusWrapper' => [Status::class, 'wrap'],
+            'logger' => LoggerFactory::getInstance('FileOperation'),
+        ]);
+    }
+
+    /**
+     * Whether local image caching is enabled for this repo.
+     */
+    public function cacheImagesEnabled(): bool
+    {
+        return $this->imageCacheExpiry > 0;
+    }
+
+    /**
+     * Image-cache TTL in seconds; 0 when caching is disabled. Also governs
+     * the manifest/info.json WAN cache (see CachedHttpManifestFetcher).
+     */
+    public function imageCacheExpiry(): int
+    {
+        return $this->imageCacheExpiry;
     }
 
     /**

--- a/tests/phpunit/Integration/IIIFImageCacheTest.php
+++ b/tests/phpunit/Integration/IIIFImageCacheTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Tests\Integration;
+
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\IIIFImageCache;
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo;
+use MediaWiki\Http\HttpRequestFactory;
+use MediaWiki\MainConfigNames;
+use MediaWikiIntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Wikimedia\FileBackend\FSFileBackend;
+
+/**
+ * Real-backend integration test for the local image cache.
+ */
+#[CoversClass(IIIFImageCache::class)]
+#[CoversClass(Repo::class)]
+class IIIFImageCacheTest extends MediaWikiIntegrationTestCase
+{
+    private const REMOTE = 'https://provider.example/iiif/2/df_x/full/800,/0/default.jpg';
+    private const BYTES = 'jpeg-bytes-payload';
+
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tmpDir = wfTempDir() . '/instantiiif-cache-' . wfRandomString(8);
+        $this->overrideConfigValue(MainConfigNames::UploadPath, '/images');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpDir !== '' && is_dir($this->tmpDir)) {
+            $this->removeRecursive($this->tmpDir);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * A repo with caching on (the default) and no injected backend builds its
+     * own FSFileBackend that knows the dedicated `iiif-cache` container and
+     * roots it at an absolute path under `directory`.
+     */
+    public function testRepoBuildsFsBackendWithAbsoluteCacheContainer(): void
+    {
+        $repo = $this->makeRepo();
+
+        $backend = $repo->getBackend();
+        self::assertInstanceOf(FSFileBackend::class, $backend);
+
+        $zonePath = $repo->getZonePath('thumb');
+        self::assertIsString($zonePath);
+        self::assertStringContainsString('iiif-cache', $zonePath);
+        // The thumb zone must resolve to a real, preparable filesystem
+        // location — the bug was that it resolved to nowhere.
+        self::assertTrue($backend->prepare(['dir' => $zonePath])->isOK());
+        self::assertSame('/images/iiif-cache', $repo->getZoneUrl('thumb'));
+    }
+
+    /**
+     * On a miss the bytes are fetched once and written through the real
+     * backend; the returned URL is served from the local cache zone and the
+     * file physically lands under `<directory>/iiif-cache`.
+     */
+    public function testFetchesStoresAndServesFromRealBackend(): void
+    {
+        $repo = $this->makeRepo();
+        $cache = new IIIFImageCache(
+            $repo,
+            $this->httpFactoryReturning(true, self::BYTES),
+            Repo::DEFAULT_IMAGE_CACHE_EXPIRY,
+            5
+        );
+
+        $url = $cache->localUrlFor(self::REMOTE);
+
+        self::assertIsString($url);
+        self::assertStringStartsWith('/images/iiif-cache/', $url);
+
+        $stored = $this->findStoredFile();
+        self::assertNotNull($stored, 'cache write did not reach the filesystem');
+        self::assertSame(self::BYTES, file_get_contents($stored));
+    }
+
+    /**
+     * A second lookup is served from the stored copy without any provider
+     * traffic — proven by wiring an HTTP factory that would fail if called.
+     */
+    public function testSecondLookupServesFromDiskWithoutFetching(): void
+    {
+        $repo = $this->makeRepo();
+
+        $miss = new IIIFImageCache(
+            $repo,
+            $this->httpFactoryReturning(true, self::BYTES),
+            Repo::DEFAULT_IMAGE_CACHE_EXPIRY,
+            5
+        );
+        $first = $miss->localUrlFor(self::REMOTE);
+        self::assertIsString($first);
+
+        // execute() would report failure if reached — a hit must not fetch.
+        $hit = new IIIFImageCache(
+            $repo,
+            $this->httpFactoryReturning(false, ''),
+            Repo::DEFAULT_IMAGE_CACHE_EXPIRY,
+            5
+        );
+
+        self::assertSame($first, $hit->localUrlFor(self::REMOTE));
+    }
+
+    private function makeRepo(): Repo
+    {
+        return new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'directory' => $this->tmpDir,
+            'iiifSources' => [],
+        ]);
+    }
+
+    private function httpFactoryReturning(bool $ok, string $body): HttpRequestFactory
+    {
+        $request = $this->createStub(\MWHttpRequest::class);
+        $request->method('execute')->willReturn(new \StatusValue($ok));
+        $request->method('getContent')->willReturn($body);
+
+        $factory = $this->createStub(HttpRequestFactory::class);
+        $factory->method('create')->willReturn($request);
+        return $factory;
+    }
+
+    /**
+     * Locate the single cached `.jpg` written under the cache container.
+     */
+    private function findStoredFile(): ?string
+    {
+        $root = $this->tmpDir . '/iiif-cache';
+        if (!is_dir($root)) {
+            return null;
+        }
+        $iter = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iter as $file) {
+            if ($file->isFile() && $file->getExtension() === 'jpg') {
+                return $file->getPathname();
+            }
+        }
+        return null;
+    }
+
+    private function removeRecursive(string $dir): void
+    {
+        $iter = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iter as $path) {
+            $path->isDir() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/phpunit/Integration/IIIFImageCacheTest.php
+++ b/tests/phpunit/Integration/IIIFImageCacheTest.php
@@ -61,6 +61,26 @@ class IIIFImageCacheTest extends MediaWikiIntegrationTestCase
     }
 
     /**
+     * `backend` given as a *string* is a backend name, not an injected object,
+     * so we still build the FSFileBackend ourselves — but under the admin's
+     * name rather than the derived `<repo>-backend` default.
+     */
+    public function testNamedBackendKeepsItsConfiguredName(): void
+    {
+        $repo = $this->makeRepo(['backend' => 'admin-named-backend']);
+
+        $backend = $repo->getBackend();
+        self::assertInstanceOf(FSFileBackend::class, $backend);
+        self::assertSame('admin-named-backend', $backend->getName());
+
+        // Still a working cache zone — naming it must not cost the wiring.
+        $zonePath = $repo->getZonePath('thumb');
+        self::assertIsString($zonePath);
+        self::assertStringContainsString('iiif-cache', $zonePath);
+        self::assertTrue($backend->prepare(['dir' => $zonePath])->isOK());
+    }
+
+    /**
      * On a miss the bytes are fetched once and written through the real
      * backend; the returned URL is served from the local cache zone and the
      * file physically lands under `<directory>/iiif-cache`.
@@ -113,14 +133,17 @@ class IIIFImageCacheTest extends MediaWikiIntegrationTestCase
         self::assertSame($first, $hit->localUrlFor(self::REMOTE));
     }
 
-    private function makeRepo(): Repo
+    /**
+     * @param array<string, mixed> $extra
+     */
+    private function makeRepo(array $extra = []): Repo
     {
-        return new Repo([
+        return new Repo(array_merge([
             'name' => 'iiif',
             'class' => Repo::class,
             'directory' => $this->tmpDir,
             'iiifSources' => [],
-        ]);
+        ], $extra));
     }
 
     private function httpFactoryReturning(bool $ok, string $body): HttpRequestFactory

--- a/tests/phpunit/Integration/RepoTest.php
+++ b/tests/phpunit/Integration/RepoTest.php
@@ -229,4 +229,77 @@ class RepoTest extends MediaWikiIntegrationTestCase
         // Empty title text → Title::newFromText returns null.
         $repo->newFile('');
     }
+
+    /**
+     * With caching on (the default), the repo gains a served `thumb` zone in
+     * the dedicated `iiif-cache` container — verified against the real
+     * FileRepo zone machinery (which the standalone unit stub cannot model).
+     */
+    public function testImageCacheZoneIsServedWhenCachingEnabled(): void
+    {
+        $this->overrideConfigValue(MainConfigNames::UploadPath, '/images');
+        $backend = $this->getServiceContainer()
+            ->getRepoGroup()
+            ->getLocalRepo()
+            ->getBackend();
+
+        $repo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => $backend,
+            'directory' => '/tmp/iiif',
+            'iiifSources' => [],
+        ]);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+        self::assertSame('/images/iiif-cache', $repo->getZoneUrl('thumb'));
+        self::assertStringContainsString('iiif-cache', (string) $repo->getZonePath('thumb'));
+    }
+
+    /**
+     * With caching disabled the `thumb` zone has no public URL, so the repo
+     * cannot serve a cached copy and IIIFFile keeps hotlinking the provider.
+     */
+    public function testThumbZoneUnservedWhenCachingDisabled(): void
+    {
+        $backend = $this->getServiceContainer()
+            ->getRepoGroup()
+            ->getLocalRepo()
+            ->getBackend();
+
+        $repo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => $backend,
+            'directory' => '/tmp/iiif',
+            'imageCacheExpiry' => 0,
+            'iiifSources' => [],
+        ]);
+
+        self::assertFalse($repo->cacheImagesEnabled());
+        self::assertFalse($repo->getZoneUrl('thumb'));
+    }
+
+    /**
+     * An explicitly configured `thumb` zone is respected, not overridden by
+     * the cache-zone defaults.
+     */
+    public function testExplicitThumbZoneIsRespected(): void
+    {
+        $backend = $this->getServiceContainer()
+            ->getRepoGroup()
+            ->getLocalRepo()
+            ->getBackend();
+
+        $repo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => $backend,
+            'directory' => '/tmp/iiif',
+            'zones' => ['thumb' => ['container' => 'custom-cache', 'url' => '/custom-cache']],
+            'iiifSources' => [],
+        ]);
+
+        self::assertSame('/custom-cache', $repo->getZoneUrl('thumb'));
+    }
 }

--- a/tests/phpunit/Unit/HookHandlerTest.php
+++ b/tests/phpunit/Unit/HookHandlerTest.php
@@ -137,6 +137,9 @@ class HookHandlerTest extends TestCase
         $iiifRepo = new Repo([
             'name' => 'iiif',
             'class' => Repo::class,
+            // Inject a backend so the constructor's cache-backend wiring
+            // short-circuits — the standalone suite has no FSFileBackend.
+            'backend' => new \FileBackend(),
             'directory' => '/tmp/iiif',
             'iiifSources' => [
                 ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],

--- a/tests/phpunit/Unit/IIIFFileTest.php
+++ b/tests/phpunit/Unit/IIIFFileTest.php
@@ -6,6 +6,8 @@ namespace MediaWiki\Extension\InstantIIIF\Tests\Unit;
 
 use MediaTransformError;
 use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\IIIFFile;
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\IIIFImageCache;
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\ImageCache;
 use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -668,14 +670,16 @@ class IIIFFileTest extends TestCase
     }
 
     /**
-     * The static `manifestFetcher()` factory is private and is the boundary
-     * where IIIFFile reaches into MediaWikiServices. Verify it returns a
+     * The `manifestFetcher()` factory is private and is the boundary where
+     * IIIFFile reaches into MediaWikiServices. Verify it returns a
      * CachedHttpManifestFetcher so the wiring stays correct after refactors.
+     * (Now an instance method, as the TTL is read from the repo.)
      */
     public function testManifestFetcherFactoryReturnsCachedHttpManifestFetcher(): void
     {
+        $file = $this->makeFile($this->loadFixture('manifest-fotothek-v2.json'));
         $ref = new \ReflectionMethod(IIIFFile::class, 'manifestFetcher');
-        $fetcher = $ref->invoke(null);
+        $fetcher = $ref->invoke($file);
 
         self::assertInstanceOf(
             \MediaWiki\Extension\InstantIIIF\Infrastructure\CachedHttpManifestFetcher::class,
@@ -1463,5 +1467,209 @@ class IIIFFileTest extends TestCase
         } finally {
             \MediaWiki\MediaWikiServices::$mockContentLanguageThrows = null;
         }
+    }
+
+    // ─── Local image cache wiring ──────────────────────────────────
+
+    /**
+     * Build a resolving IIIFFile whose imageCache() returns the supplied
+     * cache (or null), so the call sites in transform()/getUrl()/
+     * getUrlForPage() can be checked without a real FileBackend.
+     */
+    private function makeCachingFile(?ImageCache $cache): IIIFFile
+    {
+        $manifest = $this->loadFixture('manifest-fotothek-v2.json');
+        $title = new Title('Df_dk_0007450', NS_FILE, 'File');
+        $repo = $this->createStub(Repo::class);
+        $repo->method('iiifSources')->willReturn([
+            ['id' => 'deutsche-fotothek', 'manifestPattern' => 'https://fotothek.example/$1/manifest.json'],
+        ]);
+
+        return new class ($repo, $title, $manifest, $cache) extends IIIFFile {
+            private ?array $injectedManifest;
+            private ?ImageCache $injectedCache;
+
+            public function __construct(Repo $repo, Title $title, ?array $manifest, ?ImageCache $cache)
+            {
+                parent::__construct($repo, $title);
+                $this->injectedManifest = $manifest;
+                $this->injectedCache = $cache;
+            }
+
+            protected function ensureResolved(): ?array
+            {
+                if ($this->resolved !== null) {
+                    return $this->resolved;
+                }
+                if ($this->injectedManifest === null) {
+                    return null;
+                }
+                $this->resolved = [
+                    'provider' => 'deutsche-fotothek',
+                    'objectId' => 'df_dk_0007450',
+                    'manifestUrl' => 'https://fotothek.example/df_dk_0007450/manifest.json',
+                    'manifestRaw' => $this->injectedManifest,
+                ];
+                return $this->resolved;
+            }
+
+            protected function ensureInfoJsonFor(string $serviceId): array
+            {
+                return [];
+            }
+
+            protected function imageCache(): ?ImageCache
+            {
+                return $this->injectedCache;
+            }
+        };
+    }
+
+    private function fixedCache(string $localUrl): ImageCache
+    {
+        $cache = $this->createStub(ImageCache::class);
+        $cache->method('localUrlFor')->willReturn($localUrl);
+        return $cache;
+    }
+
+    public function testTransformReturnsCachedLocalUrlWhenCacheHits(): void
+    {
+        $local = 'https://wiki.example.org/images/iiif-cache/abc123.jpg';
+        $file = $this->makeCachingFile($this->fixedCache($local));
+
+        $thumb = $file->transform(['width' => 800]);
+
+        self::assertInstanceOf(ThumbnailImage::class, $thumb);
+        self::assertSame($local, $thumb->getUrl());
+    }
+
+    public function testTransformFullResolutionRoutesThroughCache(): void
+    {
+        $local = 'https://wiki.example.org/images/iiif-cache/full.jpg';
+        $file = $this->makeCachingFile($this->fixedCache($local));
+
+        $thumb = $file->transform([]); // no dimensions ⇒ full-res branch
+
+        self::assertInstanceOf(ThumbnailImage::class, $thumb);
+        self::assertSame($local, $thumb->getUrl());
+    }
+
+    public function testGetUrlReturnsCachedLocalUrlWhenCacheHits(): void
+    {
+        $local = 'https://wiki.example.org/images/iiif-cache/abc123.jpg';
+        $file = $this->makeCachingFile($this->fixedCache($local));
+
+        self::assertSame($local, $file->getUrl());
+        self::assertSame($local, $file->getUrlForPage(1));
+    }
+
+    public function testTransformFallsBackToRemoteWhenCacheReturnsNull(): void
+    {
+        // Cache miss/failure ⇒ localUrlFor() returns null ⇒ remote IIIF URL.
+        $cache = $this->createStub(ImageCache::class);
+        $cache->method('localUrlFor')->willReturn(null);
+        $file = $this->makeCachingFile($cache);
+
+        $thumb = $file->transform(['width' => 800]);
+
+        self::assertInstanceOf(ThumbnailImage::class, $thumb);
+        self::assertStringContainsString('800,', $thumb->getUrl());
+        self::assertStringContainsString('df_dk_0007450', $thumb->getUrl());
+    }
+
+    public function testGetUrlFallsBackToRemoteWhenNoCache(): void
+    {
+        // imageCache() returns null entirely ⇒ remote full-resolution URL.
+        $file = $this->makeCachingFile(null);
+
+        self::assertStringContainsString('/full/full/0/default.jpg', $file->getUrl());
+    }
+
+    // ─── imageCache() factory branches ─────────────────────────────
+
+    public function testImageCacheIsNullWhenRepoIsNotIiifRepo(): void
+    {
+        $title = new Title('Df_dk_0007450', NS_FILE, 'File');
+        $vanilla = new \FileRepo(['name' => 'local']);
+        $file = new class ($vanilla, $title) extends IIIFFile {
+            public function __construct(\FileRepo $repo, Title $title)
+            {
+                $this->repo = $repo;
+            }
+
+            public function exposeImageCache(): ?ImageCache
+            {
+                return $this->imageCache();
+            }
+        };
+
+        self::assertNull($file->exposeImageCache());
+    }
+
+    public function testImageCacheIsNullWhenCachingDisabled(): void
+    {
+        $repo = $this->createStub(Repo::class);
+        $repo->method('cacheImagesEnabled')->willReturn(false);
+        $file = $this->makeImageCacheProbe($repo);
+
+        self::assertNull($file->exposeImageCache());
+    }
+
+    public function testImageCacheIsBuiltWhenCachingEnabled(): void
+    {
+        $repo = $this->createStub(Repo::class);
+        $repo->method('cacheImagesEnabled')->willReturn(true);
+        $repo->method('imageCacheExpiry')->willReturn(3600);
+        $file = $this->makeImageCacheProbe($repo);
+
+        self::assertInstanceOf(IIIFImageCache::class, $file->exposeImageCache());
+    }
+
+    private function makeImageCacheProbe(Repo $repo): IIIFFile
+    {
+        $title = new Title('Df_dk_0007450', NS_FILE, 'File');
+        return new class ($repo, $title) extends IIIFFile {
+            public function exposeImageCache(): ?ImageCache
+            {
+                return $this->imageCache();
+            }
+        };
+    }
+
+    // ─── manifest fetcher TTL wiring (fetchJsonCached) ─────────────
+
+    public function testFetchJsonCachedUsesRepoExpiryAsManifestTtl(): void
+    {
+        // Caching repo ⇒ manifestCacheTtl() returns the repo's expiry. The
+        // stubbed HTTP returns an empty body, so the decoded result is null;
+        // we only assert the real fetchJsonCached → manifestFetcher path runs.
+        $repo = $this->createStub(Repo::class);
+        $repo->method('imageCacheExpiry')->willReturn(31536000);
+
+        self::assertNull($this->makeFetchProbe($repo)->exposeFetch('https://example.org/m.json'));
+    }
+
+    public function testFetchJsonCachedFallsBackToDefaultTtlWithoutIiifRepo(): void
+    {
+        // Vanilla FileRepo ⇒ manifestCacheTtl() falls back to the default TTL.
+        $probe = $this->makeFetchProbe(new \FileRepo(['name' => 'local']));
+
+        self::assertNull($probe->exposeFetch('https://example.org/m.json'));
+    }
+
+    private function makeFetchProbe(\FileRepo $repo): IIIFFile
+    {
+        $title = new Title('Df_dk_0007450', NS_FILE, 'File');
+        return new class ($repo, $title) extends IIIFFile {
+            public function __construct(\FileRepo $repo, Title $title)
+            {
+                $this->repo = $repo;
+            }
+
+            public function exposeFetch(string $url): ?array
+            {
+                return $this->fetchJsonCached($url);
+            }
+        };
     }
 }

--- a/tests/phpunit/Unit/Infrastructure/CachedHttpManifestFetcherTest.php
+++ b/tests/phpunit/Unit/Infrastructure/CachedHttpManifestFetcherTest.php
@@ -89,4 +89,56 @@ class CachedHttpManifestFetcherTest extends TestCase
             $this->makeFetcher($request)->fetch('https://example.org/scalar.json')
         );
     }
+
+    public function testCustomTtlIsPassedToWanCache(): void
+    {
+        $cache = $this->recordingCache();
+        $this->fetcherWithTtl($cache, 99999)->fetch('https://example.org/manifest.json');
+
+        self::assertSame(99999, $cache->lastTtl);
+    }
+
+    public function testNonPositiveTtlFallsBackToDefault(): void
+    {
+        $cache = $this->recordingCache();
+        $this->fetcherWithTtl($cache, 0)->fetch('https://example.org/manifest.json');
+
+        self::assertSame(CachedHttpManifestFetcher::DEFAULT_TTL_SECONDS, $cache->lastTtl);
+    }
+
+    public function testOmittedTtlFallsBackToDefault(): void
+    {
+        $cache = $this->recordingCache();
+        $this->fetcherWithTtl($cache, null)->fetch('https://example.org/manifest.json');
+
+        self::assertSame(CachedHttpManifestFetcher::DEFAULT_TTL_SECONDS, $cache->lastTtl);
+    }
+
+    private function recordingCache(): WANObjectCache
+    {
+        return new class extends WANObjectCache {
+            public int $lastTtl = -1;
+
+            public function getWithSetCallback(string $key, int $ttl, callable $callback, array $opts = []): mixed
+            {
+                $this->lastTtl = $ttl;
+                return $callback();
+            }
+        };
+    }
+
+    private function fetcherWithTtl(WANObjectCache $cache, ?int $ttl): CachedHttpManifestFetcher
+    {
+        $request = $this->createStub(MWHttpRequest::class);
+        $request->method('execute')->willReturn(new StatusValue(true));
+        $request->method('getContent')->willReturn('{"label":"Foo"}');
+
+        $httpFactory = $this->createStub(HttpRequestFactory::class);
+        $httpFactory->method('create')->willReturn($request);
+
+        $config = $this->createStub(Config::class);
+        $config->method('get')->willReturn(5);
+
+        return new CachedHttpManifestFetcher($cache, $httpFactory, $config, $ttl);
+    }
 }

--- a/tests/phpunit/Unit/Infrastructure/IIIFImageCacheTest.php
+++ b/tests/phpunit/Unit/Infrastructure/IIIFImageCacheTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Tests\Unit\Infrastructure;
+
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\IIIFImageCache;
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo;
+use MediaWiki\Http\HttpRequestFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for IIIFImageCache: the disabled / no-zone short-circuits, the
+ * cache-hit path (no provider traffic), the miss path (fetch + store), and
+ * the failure fall-backs (fetch failure, empty body, store failure) — all of
+ * which must return null so IIIFFile falls back to hotlinking the remote URL.
+ */
+#[CoversClass(IIIFImageCache::class)]
+class IIIFImageCacheTest extends TestCase
+{
+    private const REMOTE = 'https://provider.example/iiif/2/df_x/full/800,/0/default.jpg';
+    private const ZONE_PATH = 'mwstore://iiif-backend/iiif-cache';
+    private const ZONE_URL = '/images/iiif-cache';
+
+    /**
+     * @param string|false $zoneUrl
+     */
+    private function repoStub(
+        ?string $zonePath = self::ZONE_PATH,
+        $zoneUrl = self::ZONE_URL,
+        string $hashPath = '',
+        ?\FileBackend $backend = null
+    ): Repo {
+        $repo = $this->createStub(Repo::class);
+        $repo->method('getZonePath')->willReturn($zonePath);
+        $repo->method('getZoneUrl')->willReturn($zoneUrl);
+        $repo->method('getHashPath')->willReturn($hashPath);
+        $repo->method('getBackend')->willReturn($backend ?? new \FileBackend());
+        return $repo;
+    }
+
+    private function httpFactoryReturning(bool $ok, string $body): HttpRequestFactory
+    {
+        $request = $this->createStub(\MWHttpRequest::class);
+        $request->method('execute')->willReturn(new \StatusValue($ok));
+        $request->method('getContent')->willReturn($body);
+
+        $factory = $this->createStub(HttpRequestFactory::class);
+        $factory->method('create')->willReturn($request);
+        return $factory;
+    }
+
+    private function backend(bool $exists, bool $storeOk = true): \FileBackend
+    {
+        $backend = $this->createStub(\FileBackend::class);
+        $backend->method('fileExists')->willReturn($exists);
+        $backend->method('prepare')->willReturn(new \StatusValue(true));
+        $backend->method('quickCreate')->willReturn(new \StatusValue($storeOk));
+        return $backend;
+    }
+
+    private function expectedUrl(string $hashPath = ''): string
+    {
+        return self::ZONE_URL . '/' . $hashPath . sha1(self::REMOTE) . '.jpg';
+    }
+
+    public function testReturnsNullWhenCachingDisabled(): void
+    {
+        $cache = new IIIFImageCache($this->repoStub(), $this->httpFactoryReturning(true, 'x'), 0, 5);
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsNullWhenZoneUrlNotConfigured(): void
+    {
+        // Default FileRepo `thumb` zone with no `url` ⇒ getZoneUrl() === false.
+        $cache = new IIIFImageCache(
+            $this->repoStub(self::ZONE_PATH, false),
+            $this->httpFactoryReturning(true, 'x'),
+            3600,
+            5
+        );
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsNullWhenZonePathMissing(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(null, self::ZONE_URL),
+            $this->httpFactoryReturning(true, 'x'),
+            3600,
+            5
+        );
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsLocalUrlOnCacheHitWithoutFetching(): void
+    {
+        // execute() would fail if called — proves a hit never hits the network.
+        $cache = new IIIFImageCache(
+            $this->repoStub(backend: $this->backend(exists: true)),
+            $this->httpFactoryReturning(false, ''),
+            3600,
+            5
+        );
+
+        self::assertSame($this->expectedUrl(), $cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testFetchesAndStoresOnMiss(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(backend: $this->backend(exists: false, storeOk: true)),
+            $this->httpFactoryReturning(true, 'jpeg-bytes'),
+            3600,
+            5
+        );
+
+        self::assertSame($this->expectedUrl(), $cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testIncludesHashPathInLocalUrl(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(hashPath: 'a/ab/', backend: $this->backend(exists: true)),
+            $this->httpFactoryReturning(false, ''),
+            3600,
+            5
+        );
+
+        self::assertSame($this->expectedUrl('a/ab/'), $cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsNullWhenFetchFails(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(backend: $this->backend(exists: false)),
+            $this->httpFactoryReturning(false, ''),
+            3600,
+            5
+        );
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsNullWhenFetchBodyEmpty(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(backend: $this->backend(exists: false)),
+            $this->httpFactoryReturning(true, ''),
+            3600,
+            5
+        );
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+
+    public function testReturnsNullWhenStoreFails(): void
+    {
+        $cache = new IIIFImageCache(
+            $this->repoStub(backend: $this->backend(exists: false, storeOk: false)),
+            $this->httpFactoryReturning(true, 'jpeg-bytes'),
+            3600,
+            5
+        );
+
+        self::assertNull($cache->localUrlFor(self::REMOTE));
+    }
+}

--- a/tests/phpunit/Unit/RepoCacheConfigTest.php
+++ b/tests/phpunit/Unit/RepoCacheConfigTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MediaWiki\Extension\InstantIIIF\Tests\Unit;
+
+use MediaWiki\Extension\InstantIIIF\Infrastructure\MediaWiki\Repo;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage for Repo's image-cache configuration: the on-by-default
+ * expiry, the disable switch, a custom TTL, and the early-return when a
+ * `thumb` zone is configured explicitly (which withCacheZone() must not
+ * override). Construction also exercises withCacheZone() itself.
+ *
+ * Zone/URL resolution against a real FileBackend lives in the integration
+ * RepoTest, and the real-FSFileBackend cache round-trip in the integration
+ * IIIFImageCacheTest; here the standalone FileRepo stub only stores the
+ * $info. Each repo is given a stub `backend` object so the constructor's
+ * withCacheBackend() short-circuits instead of reaching for MW's backend
+ * service wiring (absent from the standalone suite).
+ */
+#[CoversClass(Repo::class)]
+class RepoCacheConfigTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $extra
+     */
+    private function makeRepo(array $extra = []): Repo
+    {
+        return new Repo(array_merge([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => new \FileBackend(),
+            'directory' => '/tmp/iiif',
+            'iiifSources' => [
+                ['id' => 'fotothek', 'idPattern' => '/^df_/'],
+            ],
+        ], $extra));
+    }
+
+    public function testImageCachingEnabledByDefault(): void
+    {
+        $repo = $this->makeRepo();
+
+        self::assertTrue($repo->cacheImagesEnabled());
+        self::assertSame(Repo::DEFAULT_IMAGE_CACHE_EXPIRY, $repo->imageCacheExpiry());
+    }
+
+    public function testImageCachingDisabledWhenExpiryZero(): void
+    {
+        $repo = $this->makeRepo(['imageCacheExpiry' => 0]);
+
+        self::assertFalse($repo->cacheImagesEnabled());
+        self::assertSame(0, $repo->imageCacheExpiry());
+    }
+
+    public function testCustomExpiryIsHonoured(): void
+    {
+        $repo = $this->makeRepo(['imageCacheExpiry' => 1234]);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+        self::assertSame(1234, $repo->imageCacheExpiry());
+    }
+
+    public function testConstructsWithExplicitThumbZoneWhenCachingEnabled(): void
+    {
+        // An explicit thumb zone must be respected (withCacheZone early-returns);
+        // construction must still succeed and report caching enabled.
+        $repo = $this->makeRepo([
+            'zones' => ['thumb' => ['container' => 'custom', 'url' => '/custom']],
+        ]);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+    }
+
+    public function testNonArrayZonesConfigIsCoercedBeforeAddingCacheZone(): void
+    {
+        // A malformed (non-array) `zones` value must be replaced rather than
+        // crashing when the cache zone is assembled.
+        $repo = $this->makeRepo(['zones' => 'not-an-array']);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+    }
+
+    public function testDefaultsDirectoryAndStillConfiguresCache(): void
+    {
+        // Omit `directory` so the upload-dir default branch runs alongside
+        // the (default-on) cache-zone assembly.
+        $repo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => new \FileBackend(),
+            'iiifSources' => [],
+        ]);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+    }
+}

--- a/tests/phpunit/Unit/RepoCacheConfigTest.php
+++ b/tests/phpunit/Unit/RepoCacheConfigTest.php
@@ -75,6 +75,31 @@ class RepoCacheConfigTest extends TestCase
         self::assertTrue($repo->cacheImagesEnabled());
     }
 
+    public function testNamedBackendIsLeftAloneWhenThumbZoneIsRelocated(): void
+    {
+        // Caching on, but the admin relocated the `thumb` zone to a container
+        // they back themselves and named their backend as a string (the usual
+        // $wgForeignFileRepos shape). withCacheBackend() must early-return and
+        // leave that backend alone: the cache container is not ours to wire.
+        //
+        // The assertion is that construction *succeeds*. Falling through to
+        // buildCacheBackend() here would fatal — the standalone suite stubs
+        // neither FSFileBackend nor MediaWiki's backend service wiring — so
+        // this fails loudly if the early return regresses.
+        $repo = new Repo([
+            'name' => 'iiif',
+            'class' => Repo::class,
+            'backend' => 'admin-managed-backend',
+            'directory' => '/tmp/iiif',
+            'zones' => ['thumb' => ['container' => 'custom', 'url' => '/custom']],
+            'iiifSources' => [
+                ['id' => 'fotothek', 'idPattern' => '/^df_/'],
+            ],
+        ]);
+
+        self::assertTrue($repo->cacheImagesEnabled());
+    }
+
     public function testNonArrayZonesConfigIsCoercedBeforeAddingCacheZone(): void
     {
         // A malformed (non-array) `zones` value must be replaced rather than

--- a/tests/phpunit/stubs/global-classes.php
+++ b/tests/phpunit/stubs/global-classes.php
@@ -18,6 +18,23 @@ if (!interface_exists(Config::class)) {
 if (!class_exists(FileBackend::class)) {
     class FileBackend
     {
+        /** @param array<string, mixed> $params */
+        public function fileExists(array $params): bool
+        {
+            return false;
+        }
+
+        /** @param array<string, mixed> $params */
+        public function prepare(array $params): StatusValue
+        {
+            return new StatusValue(true);
+        }
+
+        /** @param array<string, mixed> $params */
+        public function quickCreate(array $params): StatusValue
+        {
+            return new StatusValue(true);
+        }
     }
 }
 
@@ -48,6 +65,22 @@ if (!class_exists(FileRepo::class)) {
         public function getBackend(): FileBackend
         {
             return new FileBackend();
+        }
+
+        public function getZonePath(string $zone): ?string
+        {
+            return null;
+        }
+
+        /** @return string|false */
+        public function getZoneUrl(string $zone, ?string $ext = null)
+        {
+            return false;
+        }
+
+        public function getHashPath(string $name): string
+        {
+            return '';
         }
     }
 }
@@ -377,6 +410,7 @@ if (!class_exists(GlobalVarConfig::class)) {
                 'InstantIIIFDefaultTimeout' => 5,
                 'ScriptPath' => '/w',
                 'UploadDirectory' => '/var/www/uploads',
+                'UploadPath' => '/images',
                 default => null,
             };
         }

--- a/tests/phpunit/stubs/mediawiki-namespaced.php
+++ b/tests/phpunit/stubs/mediawiki-namespaced.php
@@ -196,6 +196,7 @@ namespace MediaWiki {
             public const ScriptPath = 'ScriptPath';
             public const Script = 'Script';
             public const UploadDirectory = 'UploadDirectory';
+            public const UploadPath = 'UploadPath';
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
Images are hotlinked from remote IIIF provider.


**What is the new behavior (if this is a feature change)?**
Images are loaded into cache and served from there.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No. Cache is enabled by default, so adjustments to cache settings might be necessary, though.


**Other information**:
