### PR TITLE
Load `mediaSearch` widget only when user has edit rights

### DIFF
--- a/.github/workflows/quality-assurance-assets.yml
+++ b/.github/workflows/quality-assurance-assets.yml
@@ -9,9 +9,5 @@ jobs:
   wp-scripts-lint:
     uses: inpsyde/reusable-workflows/.github/workflows/wp-scripts-lint.yml@main
     with:
-      # The reusable workflow defaults to Node 18. @wordpress/eslint-plugin
-      # eagerly loads every rule, and no-unknown-ds-tokens.js require()s an
-      # ESM-only module — which needs a Node with require(ESM) support
-      # (>= 20.19 / >= 22.12). On 18 it dies with ERR_REQUIRE_ESM.
       NODE_VERSION: '22'
       LINT_TOOLS: '["js", "md-docs"]'

--- a/.phpstan/stubs/MediaWiki.stub.php
+++ b/.phpstan/stubs/MediaWiki.stub.php
@@ -147,6 +147,11 @@ class OutputPage {
     public function addHTML(string $html): void {}
     /** @param string $key @param mixed ...$params */
     public function addWikiMsg(string $key, ...$params): void {}
+    public function getAuthority(): Authority {}
+}
+
+interface Authority {
+    public function isAllowed(string $right): bool;
 }
 
 class Skin {

--- a/src/Infrastructure/MediaWiki/HookHandler.php
+++ b/src/Infrastructure/MediaWiki/HookHandler.php
@@ -26,7 +26,7 @@ class HookHandler implements
     }
 
     /**
-     * Load the RL module on every page.
+     * Load the RL modules for the page.
      *
      * On File: pages with an IIIF file, also pass the provider URL as a
      * JS config variable so the client-side code can fix the shared-upload
@@ -43,7 +43,7 @@ class HookHandler implements
         $out->addModules(['ext.instantIIIF.mmvPatch']);
 
         $iiifRepos = $this->collectIIIFRepoDescriptors();
-        if ($iiifRepos !== []) {
+        if ($iiifRepos !== [] && $out->getAuthority()->isAllowed('edit')) {
             $out->addJsConfigVars('wgInstantIIIFRepos', $iiifRepos);
             $out->addModules(['ext.instantIIIF.mediaSearch']);
         }

--- a/tests/phpunit/Unit/HookHandlerTest.php
+++ b/tests/phpunit/Unit/HookHandlerTest.php
@@ -167,6 +167,34 @@ class HookHandlerTest extends TestCase
         );
     }
 
+    public function testOnBeforePageDisplaySkipsMediaSearchModuleForUsersWithoutEditRight(): void
+    {
+        $out = new OutputPage();
+        $out->rights = [];
+        $skin = new Skin();
+
+        $iiifRepo = new Repo([
+            'name' => 'iiif',
+            'backend' => new \FileBackend(),
+            'directory' => '/tmp/iiif',
+            'iiifSources' => [
+                ['id' => 'fotothek', 'idPattern' => '/^(df_.+)$/'],
+            ],
+        ]);
+
+        $repoGroup = $this->createStub(\RepoGroup::class);
+        $repoGroup->method('forEachForeignRepo')
+            ->willReturnCallback(static function (callable $cb) use ($iiifRepo): bool {
+                $cb($iiifRepo);
+                return false;
+            });
+
+        $this->makeHandler($repoGroup)->onBeforePageDisplay($out, $skin);
+
+        self::assertNotContains('ext.instantIIIF.mediaSearch', $out->modules);
+        self::assertArrayNotHasKey('wgInstantIIIFRepos', $out->jsConfigVars);
+    }
+
     public function testOnBeforePageDisplaySkipsMediaSearchModuleWithoutIIIFRepo(): void
     {
         $out = new OutputPage();

--- a/tests/phpunit/stubs/global-classes.php
+++ b/tests/phpunit/stubs/global-classes.php
@@ -332,10 +332,17 @@ if (!class_exists(OutputPage::class)) {
         /** @var list<array{key: string, params: array<int, mixed>}> */
         public array $wikiMessages = [];
         private ?\MediaWiki\Title\Title $title = null;
+        /** @var list<string> Rights the stub authority grants. */
+        public array $rights = ['edit'];
 
         public function setTitle(\MediaWiki\Title\Title $title): void
         {
             $this->title = $title;
+        }
+
+        public function getAuthority(): Authority
+        {
+            return new Authority($this->rights);
         }
 
         public function addModules($modules): void
@@ -378,6 +385,21 @@ if (!class_exists(OutputPage::class)) {
 if (!class_exists(Skin::class)) {
     class Skin
     {
+    }
+}
+
+if (!class_exists(Authority::class)) {
+    class Authority
+    {
+        /** @param list<string> $rights */
+        public function __construct(private array $rights = [])
+        {
+        }
+
+        public function isAllowed(string $right): bool
+        {
+            return in_array($right, $this->rights, true);
+        }
     }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
`mediaSearch` widget is loaded unconditionally, loading ~400KB (uncompressed) on every page.


**What is the new behavior (if this is a feature change)?**
`mediaSearch` is only loaded when the current user has editing permissions.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
