### PR TITLE
Improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,56 @@
 version: 2
+
 updates:
-  - package-ecosystem: composer
-    directory: /
+  - package-ecosystem: "composer"
+    directory: "/"
     schedule:
-      interval: monthly
-  - package-ecosystem: github-actions
-    directory: /
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    groups:
+      composer-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      composer-production:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      composer-development:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: monthly
-  - package-ecosystem: npm
-    directory: /
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-production:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      npm-development:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      github-actions-updates:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
The Dependabot config is flat and ungrouped: every ecosystem gets the same weekly check with no `groups`, `cooldown`, or labels, so each dependency update opens its own PR. A critical security fix is indistinguishable from a devDependency patch bump in the PR list, forcing reviewers to open every PR to find out which ones matter.


**What is the new behavior (if this is a feature change)?**
Security updates are consolidated into a per-ecosystem `applies-to: security-updates` group with distinct labels so they stand out immediately and are never delayed by cooldown. Routine patch/minor updates are grouped by ecosystem and dependency type (production/development) behind a cooldown of 3 days (14 for majors), collapsing the PR stream to a handful per week while major bumps still surface individually for deliberate review.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
